### PR TITLE
Add Dockerized test coverage

### DIFF
--- a/application/response_handlers/main.py
+++ b/application/response_handlers/main.py
@@ -54,6 +54,36 @@ class SpotifyResponseController:
         "artists": GetSeveralArtistsResponseHandler,
     }
 
+    @classmethod
+    def resolve_handler(cls, request_url):
+        """Return the response handler class for a request URL.
+
+        Batch endpoints (GET /v1/{type}?ids=...) route by resource type; every
+        other URL is normalized (strip port/query/fragment, and the trailing id
+        segment for non-/me URLs) and looked up by path. Raises ValueError if no
+        handler matches.
+        """
+        parsed = urlparse(request_url)
+
+        if "ids" in parse_qs(parsed.query):
+            resource_type = parsed.path.rstrip("/").rsplit("/", maxsplit=1)[-1]
+            try:
+                return cls.BATCH_RESPONSE_HANDLER_MAPPING[resource_type]
+            except KeyError:
+                raise ValueError(
+                    f'No batch response handler for resource type "{resource_type}": {request_url}'
+                )
+
+        normalized = parsed._replace(
+            netloc=parsed.netloc.split(":")[0], query="", fragment=""
+        )
+        if not request_url.startswith("https://api.spotify.com/v1/me"):
+            normalized = normalized._replace(path=normalized.path.rsplit("/", maxsplit=1)[0])
+        try:
+            return cls.RESPONSE_HANDLER_URL_MAPPING[normalized.geturl()]
+        except KeyError:
+            raise ValueError(f'No response handler maps to the following URL: {request_url}')
+
     @staticmethod
     def dispatch_to_response_parser(ch, method, properties, body):
         global RESPONSE_HANDLER_ACTION
@@ -64,33 +94,7 @@ class SpotifyResponseController:
         depth_of_search = msg["depth_of_search"]
         response = msg["response"]
 
-        parsed_request_url = urlparse(request_url)
-
-        if "ids" in parse_qs(parsed_request_url.query):
-            # Batch endpoint: GET /v1/{resource_type}?ids=...
-            resource_type = parsed_request_url.path.rstrip("/").rsplit("/", maxsplit=1)[-1]
-            try:
-                response_handler = SpotifyResponseController.BATCH_RESPONSE_HANDLER_MAPPING[resource_type]
-            except KeyError:
-                raise ValueError(
-                    f'No batch response handler for resource type "{resource_type}": {request_url}'
-                )
-        else:
-            # Make the request URL uniform so we can look up the single/collection handler.
-            normalized = parsed_request_url._replace(
-                netloc=parsed_request_url.netloc.split(":")[0],
-                query="",
-                fragment="",
-            )
-            if not request_url.startswith("https://api.spotify.com/v1/me"):
-                normalized = normalized._replace(
-                    path=normalized.path.rsplit("/", maxsplit=1)[0]
-                )
-
-            try:
-                response_handler = SpotifyResponseController.RESPONSE_HANDLER_URL_MAPPING[normalized.geturl()]
-            except KeyError:
-                raise ValueError(f'No response handler maps to the following URL: {request_url}')
+        response_handler = SpotifyResponseController.resolve_handler(request_url)
 
         if RESPONSE_HANDLER_ACTION == ResponsesExchange.ROUTING_KEY_WRITE_TO_DISK.value:
             response_handler(request_url, depth_of_search, response).write_to_disk()

--- a/application/spotify_authentication/api_authorization_web_service.py
+++ b/application/spotify_authentication/api_authorization_web_service.py
@@ -109,13 +109,18 @@ class SpotifyAuthCodeResource:
         </html>'''
 
 
-def serve_the_app():
+def create_app():
     app = falcon.App()
     app.add_route('/login', SpotifyLoginResource())
     app.add_route('/callback', SpotifyAuthCodeResource())
+    return app
+
+
+def serve_the_app():
+    app = create_app()
 
     with make_server('', 8000, app) as httpd:
-        print('Starting to serve at http://localhost:8000/login')
+        print('Starting to serve at http://127.0.0.1:8000/login')
         # Serve until process is killed
         httpd.serve_forever()
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -168,6 +168,27 @@ services:
       - redis
     command: bash -c "sleep 5 && python3.11 application/requests_factory.py"
 
+  tests:
+    image: "spotify-power-browser:latest"
+    # Test runner -- not part of the normal `up`. Run with:
+    #   docker compose run --rm tests
+    # It brings up rabbitmq + redis; the Neo4j tests use the host Desktop and
+    # skip if it isn't running. Tests are mounted so they change without a rebuild.
+    profiles: ["test"]
+    environment:
+      NEO4J_HOSTNAME: host.docker.internal
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - "./secrets:/src/secrets"
+      - "./tests:/src/tests"
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command: python3.11 -m pytest tests/
+
 volumes:
   redis_data:
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -547,6 +547,17 @@ files = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
+    {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
+]
+
+[[package]]
 name = "ipykernel"
 version = "6.22.0"
 description = "IPython Kernel for Jupyter"
@@ -1436,6 +1447,21 @@ docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.2.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
+
+[[package]]
 name = "prometheus-client"
 version = "0.16.0"
 description = "Python client for the Prometheus monitoring system."
@@ -1588,6 +1614,27 @@ files = [
     {file = "pyrsistent-0.19.3-py3-none-any.whl", hash = "sha256:ccf0d6bd208f8111179f0c26fdf84ed7c3891982f2edaeae7422575f47e66b64"},
     {file = "pyrsistent-0.19.3.tar.gz", hash = "sha256:1a2994773706bbb4995c31a97bc94f1418314923bd1048c6d964837040376440"},
 ]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
+    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+iniconfig = ">=1"
+packaging = ">=20"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -2158,4 +2205,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "8ff9fe211126e39b0ad562161cd0a28eb7a93c03de65ff8f9a9dda1f47336c11"
+content-hash = "a9009beeb8ea8efed0d31af7725b149bd37dea484610ecfb9b0ff431d52303e8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,15 @@ jinja2 = "^3.1.4"
 redis = "^5.0.0"
 
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0.0"
+
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,111 @@
+"""Shared test fixtures.
+
+`make` exposes small factories for the Spotify object shapes the handlers and
+Cypher consume. The service fixtures (redis_client / rabbitmq_channel /
+neo4j_driver) connect to the real backing services and `pytest.skip()` when one
+isn't reachable, so the suite runs anywhere and the integration tests light up
+when the services are up (e.g. via the Docker Compose `tests` service).
+"""
+from types import SimpleNamespace
+
+import pytest
+
+
+def _artist(i):
+    return {
+        "uri": f"spotify:artist:{i}",
+        "id": f"art{i}",
+        "name": f"Artist {i}",
+        "external_urls": {"spotify": f"https://open.spotify.com/artist/art{i}"},
+        "href": f"https://api.spotify.com/v1/artists/art{i}",
+        "type": "artist",
+        "genres": [],
+    }
+
+
+def _album(i, artists=None):
+    return {
+        "uri": f"spotify:album:{i}",
+        "id": f"alb{i}",
+        "name": f"Album {i}",
+        "release_date": "2020-01-01",
+        "release_date_precision": "day",
+        "total_tracks": 10,
+        "album_type": "album",
+        "external_urls": {"spotify": f"https://open.spotify.com/album/alb{i}"},
+        "href": f"https://api.spotify.com/v1/albums/alb{i}",
+        "type": "album",
+        "artists": [_artist(i)] if artists is None else artists,
+        "genres": [],
+    }
+
+
+def _track(i, album=None, artists=None):
+    return {
+        "uri": f"spotify:track:{i}",
+        "id": f"trk{i}",
+        "name": f"Track {i}",
+        "explicit": False,
+        "is_local": False,
+        "duration_ms": 200000,
+        "popularity": 50,
+        "type": "track",
+        "href": f"https://api.spotify.com/v1/tracks/trk{i}",
+        "external_urls": {"spotify": f"https://open.spotify.com/track/trk{i}"},
+        "album": _album(i) if album is None else album,
+        "artists": [_artist(i)] if artists is None else artists,
+    }
+
+
+def _liked_page(tracks, offset=0, next_url=None):
+    return {
+        "href": "https://api.spotify.com/v1/me/tracks",
+        "items": [{"added_at": "2021-01-01T00:00:00Z", "track": t} for t in tracks],
+        "limit": 20,
+        "offset": offset,
+        "next": next_url,
+        "total": 100,
+    }
+
+
+@pytest.fixture
+def make():
+    """Factories for Spotify object shapes: make.track/album/artist/liked_page."""
+    return SimpleNamespace(artist=_artist, album=_album, track=_track, liked_page=_liked_page)
+
+
+@pytest.fixture
+def redis_client():
+    from application.cache.redis_client import get_redis_client
+    try:
+        client = get_redis_client()
+        client.ping()
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"Redis not reachable: {exc}")
+    return client
+
+
+@pytest.fixture
+def rabbitmq_channel():
+    from application.message_queue.connect import connect_to_rabbitmq_exchange
+    from application.message_queue.constants import RequestsExchange
+    try:
+        connection, channel = connect_to_rabbitmq_exchange(
+            RequestsExchange.EXCHANGE_NAME.value, RequestsExchange.EXCHANGE_TYPE.value
+        )
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"RabbitMQ not reachable: {exc}")
+    yield channel
+    connection.close()
+
+
+@pytest.fixture
+def neo4j_driver():
+    from application.config import SECRETS_DIR
+    from application.graph_database.connect import connect_to_neo4j
+    try:
+        driver = connect_to_neo4j(SECRETS_DIR / "neo4j_credentials.yaml")
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"Neo4j not reachable: {exc}")
+    yield driver
+    driver.close()

--- a/tests/test_batch_handler.py
+++ b/tests/test_batch_handler.py
@@ -1,0 +1,42 @@
+from application.response_handlers.tracks.several_tracks import GetSeveralTracksResponseHandler
+
+
+def test_items_filters_null_entries(make):
+    # Spotify's Get Several X endpoints return null for ids that don't resolve.
+    handler = GetSeveralTracksResponseHandler(None, 0, {"tracks": [make.track(1), None, make.track(2)]})
+    assert len(handler.items) == 2
+    assert all(item is not None for item in handler.items)
+
+
+def test_write_to_disk_uses_id_and_tolerates_a_bad_item(make, tmp_path, monkeypatch):
+    monkeypatch.setattr(GetSeveralTracksResponseHandler, "DISK_LOCATION", tmp_path)
+    good = make.track(1)
+    bad = {"id": "noname"}  # no "name" -> falls back to id, still written, not aborting the batch
+    GetSeveralTracksResponseHandler(None, 0, {"tracks": [good, bad]}).write_to_disk()
+
+    files = [p.name for p in tmp_path.iterdir()]
+    assert len(files) == 2  # one bad item did not abort the other write
+    # the unique id is in the filename so same-named items can't collide
+    assert any(good["id"] in name for name in files)
+
+
+def _patch_request_batch(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "application.requests_factory.SpotifyRequestFactory.request_batch",
+        classmethod(lambda cls, rtype, ids, depth_of_search=0: calls.append((rtype, list(ids), depth_of_search))),
+    )
+    return calls
+
+
+def test_follow_links_terminates_at_depth_zero(make, monkeypatch):
+    calls = _patch_request_batch(monkeypatch)
+    GetSeveralTracksResponseHandler(None, 0, {"tracks": [make.track(1)]}).follow_links()
+    assert calls == []
+
+
+def test_follow_links_batches_neighbors_at_depth(make, monkeypatch):
+    calls = _patch_request_batch(monkeypatch)
+    GetSeveralTracksResponseHandler(None, 1, {"tracks": [make.track(1)]}).follow_links()
+    assert {rtype for rtype, _, _ in calls} == {"albums", "artists"}
+    assert all(depth == 0 for _, _, depth in calls)  # depth decremented from 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,26 @@
+import application.config as config
+
+
+def test_env_bool_truthy_values(monkeypatch):
+    for v in ("true", "TRUE", "1", "yes", "on"):
+        monkeypatch.setenv("SPB_TEST_FLAG", v)
+        assert config._env_bool("SPB_TEST_FLAG", False) is True
+
+
+def test_env_bool_falsy_and_garbage_values(monkeypatch):
+    for v in ("false", "0", "no", "off", "nonsense"):
+        monkeypatch.setenv("SPB_TEST_FLAG", v)
+        assert config._env_bool("SPB_TEST_FLAG", True) is False
+
+
+def test_env_bool_unset_returns_default(monkeypatch):
+    monkeypatch.delenv("SPB_TEST_FLAG", raising=False)
+    assert config._env_bool("SPB_TEST_FLAG", True) is True
+    assert config._env_bool("SPB_TEST_FLAG", False) is False
+
+
+def test_shipped_flag_defaults():
+    # Dedup on, batch off, no reset -- the safe shipped defaults.
+    assert config.CRAWLED_URL_DEDUP is True
+    assert config.USE_BATCH_ENDPOINTS is False
+    assert config.RESET_CRAWL is False

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,0 +1,41 @@
+import pytest
+
+from application.response_handlers import (
+    GetSingleAlbumResponseHandler,
+    GetSingleArtistResponseHandler,
+    GetSingleTrackResponseHandler,
+    LikedSongsPlaylistResponseHandler,
+    GetSeveralTracksResponseHandler,
+    GetSeveralAlbumsResponseHandler,
+    GetSeveralArtistsResponseHandler,
+)
+from application.response_handlers.main import SpotifyResponseController
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://api.spotify.com/v1/tracks/abc123", GetSingleTrackResponseHandler),
+        ("https://api.spotify.com/v1/albums/abc123", GetSingleAlbumResponseHandler),
+        ("https://api.spotify.com/v1/artists/abc123", GetSingleArtistResponseHandler),
+        ("https://api.spotify.com/v1/me/tracks", LikedSongsPlaylistResponseHandler),
+        # pagination URL (offset/limit, no ids) still routes to the collection handler
+        ("https://api.spotify.com/v1/me/tracks?offset=20&limit=20", LikedSongsPlaylistResponseHandler),
+        # batch URLs route by the ?ids= resource type
+        ("https://api.spotify.com/v1/tracks?ids=a,b,c", GetSeveralTracksResponseHandler),
+        ("https://api.spotify.com/v1/albums?ids=a,b", GetSeveralAlbumsResponseHandler),
+        ("https://api.spotify.com/v1/artists?ids=a", GetSeveralArtistsResponseHandler),
+    ],
+)
+def test_resolve_handler_routes_correctly(url, expected):
+    assert SpotifyResponseController.resolve_handler(url) is expected
+
+
+def test_unmapped_url_raises_value_error():
+    with pytest.raises(ValueError):
+        SpotifyResponseController.resolve_handler("https://api.spotify.com/v1/audiobooks/xyz")
+
+
+def test_unknown_batch_resource_type_raises():
+    with pytest.raises(ValueError):
+        SpotifyResponseController.resolve_handler("https://api.spotify.com/v1/episodes?ids=a,b")

--- a/tests/test_liked_songs.py
+++ b/tests/test_liked_songs.py
@@ -1,0 +1,21 @@
+import pandas
+
+from application.response_handlers.me.my_liked_songs import LikedSongsPlaylistResponseHandler
+
+
+def test_parse_response_returns_dataframe(make):
+    # Exercises the pandas DataFrame path (guards against a pandas major bump).
+    page = make.liked_page([make.track(1), make.track(2)])
+    handler = LikedSongsPlaylistResponseHandler("https://api.spotify.com/v1/me/tracks", 0, page)
+
+    df = handler.parse_response()
+
+    assert isinstance(df, pandas.DataFrame)
+    assert len(df) == 2
+    assert {"song_name", "song_first_artist_name", "song_album_name"} <= set(df.columns)
+
+
+def test_name_property_uses_offset(make):
+    page = make.liked_page([make.track(1)], offset=40)
+    handler = LikedSongsPlaylistResponseHandler("https://api.spotify.com/v1/me/tracks", 0, page)
+    assert handler.name == "liked_songs_40"

--- a/tests/test_neo4j_cypher.py
+++ b/tests/test_neo4j_cypher.py
@@ -1,0 +1,49 @@
+import pytest
+
+from application.response_handlers.tracks.several_tracks import GetSeveralTracksResponseHandler
+
+
+@pytest.fixture(autouse=True)
+def _cleanup(neo4j_driver):
+    # neo4j_driver skips the module if Neo4j isn't reachable. Remove any nodes
+    # this module created (distinctive CYTEST uris) before and after each test.
+    purge = "MATCH (n) WHERE n.uri CONTAINS 'CYTEST' DETACH DELETE n"
+    neo4j_driver.execute_query(purge)
+    yield
+    neo4j_driver.execute_query(purge)
+
+
+def test_batch_insert_creates_track_album_artist(neo4j_driver, make):
+    artist = make.artist("CYTEST1")
+    album = make.album("CYTEST1", artists=[artist])
+    track = make.track("CYTEST1", album=album, artists=[artist])
+
+    GetSeveralTracksResponseHandler(None, 0, {"tracks": [track]}).write_to_neo4j(driver=neo4j_driver)
+
+    recs, _, _ = neo4j_driver.execute_query(
+        "MATCH (t:Track {uri: $uri}) "
+        "OPTIONAL MATCH (t)<-[:CONTAINS]-(al:Album) "
+        "OPTIONAL MATCH (t)<-[:CREATED]-(ar:Artist) "
+        "RETURN t.name AS name, al.uri AS album_uri, count(DISTINCT ar) AS artist_count",
+        uri=track["uri"],
+    )
+    row = recs[0]
+    assert row["name"] == track["name"]
+    assert row["album_uri"] == album["uri"]
+    assert row["artist_count"] >= 1
+
+
+def test_empty_album_artists_still_links_track_artists(neo4j_driver, make):
+    # Review #4: the chained-UNWIND bug dropped a track's own artists when its
+    # album had no artists. The CALL-subquery fix must keep them linked.
+    artist = make.artist("CYTEST2")
+    album = make.album("CYTEST2", artists=[])  # pathological empty album-artists
+    track = make.track("CYTEST2", album=album, artists=[artist])
+
+    GetSeveralTracksResponseHandler(None, 0, {"tracks": [track]}).write_to_neo4j(driver=neo4j_driver)
+
+    recs, _, _ = neo4j_driver.execute_query(
+        "MATCH (t:Track {uri: $uri})<-[:CREATED]-(ar:Artist) RETURN count(ar) AS c",
+        uri=track["uri"],
+    )
+    assert recs[0]["c"] >= 1

--- a/tests/test_oauth_service.py
+++ b/tests/test_oauth_service.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+@pytest.fixture
+def client():
+    # The OAuth module reads client id/secret from secrets/ at import; skip if
+    # those aren't present (e.g. running outside the Docker test service).
+    try:
+        from application.spotify_authentication.api_authorization_web_service import create_app
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"OAuth service unavailable (secrets missing?): {exc}")
+    from falcon import testing
+    return testing.TestClient(create_app())
+
+
+def test_login_redirects_to_spotify_authorize(client):
+    # Guards the Falcon app wiring (and a Falcon major bump).
+    resp = client.simulate_get("/login")
+    assert resp.status_code in (301, 302)
+    assert resp.headers["location"].startswith("https://accounts.spotify.com/authorize")
+
+
+def test_login_uses_loopback_ip_not_localhost(client):
+    # Spotify rejects http://localhost; the redirect_uri must be 127.0.0.1.
+    location = client.simulate_get("/login").headers["location"]
+    assert "redirect_uri=http%3A%2F%2F127.0.0.1%3A8000%2Fcallback" in location
+    assert "localhost" not in location

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -1,0 +1,14 @@
+from application.message_queue.connect import bind_queue_to_exchange
+from application.message_queue.constants import RequestsExchange
+
+
+def test_connect_declare_exchange_and_bind_queue(rabbitmq_channel):
+    # rabbitmq_channel skips the test if RabbitMQ isn't reachable.
+    queue_name = bind_queue_to_exchange(
+        rabbitmq_channel,
+        RequestsExchange.EXCHANGE_NAME.value,
+        RequestsExchange.EXCHANGE_TYPE.value,
+        routing_key="test_routing_key",
+        queue_name="test_queue",
+    )
+    assert queue_name == "test_queue"

--- a/tests/test_redis_dedup.py
+++ b/tests/test_redis_dedup.py
@@ -1,0 +1,38 @@
+import pytest
+
+from application.cache.redis_client import url_is_new, unmark_url, reset_crawled_set
+
+
+@pytest.fixture(autouse=True)
+def _clean(redis_client):
+    # redis_client fixture skips the whole module if Redis isn't reachable.
+    reset_crawled_set()
+    yield
+    reset_crawled_set()
+
+
+def test_first_request_new_then_deduped():
+    url = "https://api.spotify.com/v1/tracks/dedup1"
+    assert url_is_new(url, 0) is True
+    assert url_is_new(url, 0) is False
+
+
+def test_dedup_is_depth_aware():
+    url = "https://api.spotify.com/v1/tracks/dedup2"
+    assert url_is_new(url, 0) is True
+    assert url_is_new(url, 1) is True   # a deeper request is allowed through
+    assert url_is_new(url, 1) is False
+
+
+def test_unmark_makes_url_requestable_again():
+    url = "https://api.spotify.com/v1/tracks/dedup3"
+    assert url_is_new(url, 0) is True
+    unmark_url(url, 0)
+    assert url_is_new(url, 0) is True   # rolled back -> re-requestable
+
+
+def test_reset_clears_the_set():
+    url = "https://api.spotify.com/v1/tracks/dedup4"
+    url_is_new(url, 0)
+    reset_crawled_set()
+    assert url_is_new(url, 0) is True

--- a/tests/test_request_batch.py
+++ b/tests/test_request_batch.py
@@ -1,0 +1,47 @@
+import pytest
+
+from application.requests_factory import SpotifyRequestFactory
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Capture request_url calls instead of publishing to RabbitMQ."""
+    calls = []
+    monkeypatch.setattr(
+        SpotifyRequestFactory,
+        "request_url",
+        staticmethod(lambda url, depth_of_search=0: calls.append((url, depth_of_search))),
+    )
+    return calls
+
+
+def _chunk_sizes(calls):
+    return [url.split("ids=")[1].count(",") + 1 for url, _ in calls]
+
+
+def test_tracks_chunk_to_cap_of_50(captured):
+    SpotifyRequestFactory.request_batch("tracks", [f"id{i}" for i in range(120)], depth_of_search=2)
+    assert _chunk_sizes(captured) == [50, 50, 20]
+    assert all(u.startswith("https://api.spotify.com/v1/tracks?ids=") for u, _ in captured)
+    assert all(depth == 2 for _, depth in captured)
+
+
+def test_albums_chunk_to_cap_of_20(captured):
+    SpotifyRequestFactory.request_batch("albums", [f"a{i}" for i in range(45)], depth_of_search=0)
+    assert _chunk_sizes(captured) == [20, 20, 5]
+
+
+def test_artists_chunk_to_cap_of_50(captured):
+    SpotifyRequestFactory.request_batch("artists", [f"a{i}" for i in range(50)], depth_of_search=0)
+    assert _chunk_sizes(captured) == [50]
+
+
+def test_dedupes_and_drops_falsy_ids(captured):
+    SpotifyRequestFactory.request_batch("artists", ["x", "x", "y", None, "", "z"], depth_of_search=0)
+    assert len(captured) == 1
+    assert captured[0][0].split("ids=")[1].split(",") == ["x", "y", "z"]
+
+
+def test_empty_ids_is_a_noop(captured):
+    SpotifyRequestFactory.request_batch("tracks", [], depth_of_search=0)
+    assert captured == []


### PR DESCRIPTION
Adds a `pytest` suite runnable via `docker compose run --rm tests` (profile-gated; brings up RabbitMQ + Redis, targets the host Neo4j Desktop, integration tests skip if a service is down).

**Coverage (34 tests):**
- **Unit:** config flag parsing/defaults; `request_batch` id-chunking + caps (50/20/50); dispatcher URL routing (single/collection/batch + unmapped); batch handler null-filtering, collision-free disk writes, depth-gated follow; liked-songs pandas parse; Falcon OAuth `/login` redirect (asserts the `127.0.0.1` loopback redirect_uri).
- **Integration:** Redis dedup (depth-aware + rollback + reset), RabbitMQ connect/declare, Neo4j batch-insert Cypher (incl. the review #4 empty-album-artists regression).

Includes a small testability refactor (`resolve_handler` + `create_app`), no behavior change.

This is the regression net for the upcoming version bumps. It already flagged one: Falcon 3.1.1 imports `cgi` (removed in Python 3.13), so falcon 3→4 must precede the Python 3.13 bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)