### PR TITLE
docs: rewrite README + add the spin-up run skill

### DIFF
--- a/.claude/skills/spin-up/SKILL.md
+++ b/.claude/skills/spin-up/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: spin-up
+description: Set up, run, and monitor the Spotify Power Browser pipeline locally with Docker Compose — bring up the stack, drive the one-time Spotify OAuth flow (handing the login to the human), verify the crawl, and watch it run. Use whenever asked to spin up / run / start / launch / set up / boot / or monitor this project locally.
+---
+
+# Spin up & run Spotify Power Browser locally
+
+This project is a containerized crawler: `requests_factory` seeds a crawl →
+RabbitMQ → `api_call_engine` calls the Spotify API → responses fan out to
+workers that write JSON to `data/`, build a Neo4j graph, and follow links
+(recursing). Redis dedups requests. The OAuth flow is **bundled into Compose**,
+so it all comes up with one `docker compose up`.
+
+Work from the repo root: `/Users/michael/software_projects/spotify-power-browser`.
+
+## 0. Pre-flight (check before doing anything)
+
+Run these and confirm before bringing the stack up:
+```bash
+docker ps >/dev/null 2>&1 && echo "Docker: up" || echo "Docker: START Docker Desktop first"
+lsof -nP -iTCP:7687 -sTCP:LISTEN 2>/dev/null | grep -q . && echo "Neo4j: listening on 7687" || echo "Neo4j: START Neo4j Desktop (a DB on bolt://127.0.0.1:7687)"
+ls secrets/spotify_client_id.secret secrets/spotify_client_secret.secret secrets/neo4j_credentials.yaml 2>/dev/null
+```
+- **Docker Desktop** must be running.
+- **Neo4j Desktop** must have a database running on `127.0.0.1:7687`. The
+  crawler reaches it from containers via `host.docker.internal` (already wired in
+  `compose.yaml` with `extra_hosts`). Confirm `secrets/neo4j_credentials.yaml`
+  matches the Neo4j Desktop password.
+- `secrets/` must have the Spotify client id/secret. (Token files are written by
+  the auth flow.)
+
+## 1. (Optional) start fresh
+
+The Redis dedup set **persists across runs** by design (resume). For a clean
+re-crawl, either set `RESET_CRAWL=true` (step 3) or clear it, and optionally
+reset the JSON cache:
+```bash
+# preserve + clear the on-disk JSON cache (gitignored)
+mkdir -p "$HOME/spotify-power-browser-cache-backups"
+mv data/responses "$HOME/spotify-power-browser-cache-backups/responses_$(date +%Y%m%d_%H%M%S)" 2>/dev/null; mkdir -p data/responses
+```
+If reusing an old token would skip a fresh OAuth, move stale tokens aside so the
+auth gate waits for a real login:
+```bash
+mkdir -p secrets/_stale_token_backup
+for f in spotify_api_token spotify_refresh_token spotify_authorization_code; do mv "secrets/$f.secret" "secrets/_stale_token_backup/" 2>/dev/null; done
+```
+
+## 2. Build & bring up
+
+```bash
+docker compose build           # first run / after code changes
+docker compose up              # run in background (it streams logs and waits at the auth gate)
+```
+The stack starts RabbitMQ, Redis, and the response workers, then the
+`spotify_authentication` service serves the login page and the pipeline **waits**
+on a token healthcheck (patient: ~1h start_period). `api_call_engine` and
+`requests_factory` stay parked until you authorize.
+
+## 3. Drive the OAuth flow — HUMAN IN THE LOOP
+
+You (the agent) **cannot** complete the Spotify login — hand it to the human.
+- Confirm the auth page serves: `curl -sS -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8000/login` (expect `301`).
+- Open a browser to **http://127.0.0.1:8000/login** (use the Chrome DevTools MCP
+  or Claude-in-Chrome). It redirects to Spotify's login/consent.
+- **Pause and ask the human** to log into Spotify and click **Agree**. Then the
+  callback writes tokens to `secrets/`, the healthcheck flips healthy, and
+  Compose auto-starts the crawl.
+- To run a fresh crawl as it starts: bring up with `RESET_CRAWL=true docker compose up`.
+
+Detect completion:
+```bash
+ls -s secrets/spotify_api_token.secret 2>/dev/null && echo "token written" || echo "still waiting for human"
+docker inspect --format '{{.State.Health.Status}}' spotify-power-browser-spotify_authentication-1
+```
+
+> If the auth gate timed out before the human finished (older config), just
+> start the gated services manually once the token exists:
+> `docker compose up -d api_call_engine requests_factory_start_crawls`.
+
+## 4. Verify it's crawling
+
+```bash
+docker compose logs requests_factory_start_crawls | grep "STARTING FETCH"   # crawl seeded
+docker compose logs api_call_engine | grep -cE 'GET:'                       # API calls made
+find data/responses -name '*.json' | wc -l                                  # JSON landing on disk
+```
+Graph counts (one-off container against host Neo4j):
+```bash
+docker run --rm --add-host host.docker.internal:host-gateway -e NEO4J_HOSTNAME=host.docker.internal \
+  -v "$PWD/secrets:/src/secrets" spotify-power-browser:latest python3 -c "
+from application.config import SECRETS_DIR
+from application.graph_database.connect import connect_to_neo4j
+d=connect_to_neo4j(SECRETS_DIR/'neo4j_credentials.yaml')
+for l in ['Track','Album','Artist','Genre']:
+    r,_,_=d.execute_query(f'MATCH (n:{l}) RETURN count(n) c'); print(l, r[0]['c'])
+d.close()"
+```
+
+## 5. Monitor
+
+- **RabbitMQ UI — http://localhost:15672** (`guest`/`guest`), Queues tab: backlog
+  + live message rates. **Done = rates flatline to 0 + queues empty.** Rates are
+  bursty — watch the trend, not one sample.
+- `docker compose logs -f api_call_engine` (GET stream) · `... responses_write_to_neo4j` (node counts).
+- Throughput pulse: `docker compose logs --since 10s api_call_engine | grep -c 'GET:'` (0 = idle).
+
+## 6. Tests
+
+```bash
+docker compose run --rm tests        # pytest; brings up rabbitmq+redis, neo4j tests use the host Desktop
+```
+
+## 7. Tear down
+
+```bash
+docker compose down                  # stops containers; redis_data volume + Neo4j data persist
+docker compose down -v               # also wipe the Redis dedup volume
+```
+
+## Gotchas (learned the hard way)
+
+- **Redirect URI must be `http://127.0.0.1:8000/callback`**, not `localhost`
+  (Spotify rejects localhost as insecure), and it must be registered in the
+  Spotify app dashboard. Symptom: a blank page reading `redirect_uri: Insecure`.
+- **Neo4j on the host** collides with a containerized Neo4j on port 7687 — that's
+  why the compose `neo4j` service is commented out and the app points at
+  `host.docker.internal`. Don't run both.
+- **No-dedup floods get rate-limited.** A large crawl with `CRAWLED_URL_DEDUP`
+  off (or a code regression) can earn a multi-hour `429 Retry-After`. The 429
+  backoff is capped at 10 min; if you get a long ban, the crawl effectively
+  stalls — wait it out or use a different Spotify app.
+- **A plain re-run does nothing** (the dedup set persists) — use `RESET_CRAWL=true`
+  for a fresh crawl. The seeder logs a warning when every seed was already crawled.
+- **Tokens last ~1h.** Long crawls rely on the 401-refresh path; a fresh token is
+  written on each `/callback`.
+- **`USE_BATCH_ENDPOINTS` is default-off.** Only enable after probing batch access
+  with `_probe_batch_endpoints.py` (Spotify postponed, not cancelled, removing
+  the `?ids=` endpoints for existing apps).

--- a/README.md
+++ b/README.md
@@ -1,14 +1,116 @@
 # Spotify Power Browser
 
-For tastemakers and audiophiles of all kinds.
+For tastemakers and audiophiles of all kinds. A data-engineering pipeline that
+crawls the Spotify Web API and builds a graph of your musical taste in Neo4j.
 
-## How to Run
+It runs as a set of containerized workers wired together by RabbitMQ, with a
+Redis-backed crawl dedup cache — the whole thing comes up with a single
+`docker compose up`, including the one-time Spotify OAuth flow.
 
-This assumes that you have registered yourself a personal Spotify app with which to make API calls. This app should have
-a client ID and a corresponding client secret, which can be stored in `secrets/spotify_client_id.secret` and 
-`secrets/spotify_client_secret.secret`. It also assumes that you have set `secrets/neo4j_credentials.yaml` to be in
-agreement with the Docker Compose file.
+## Architecture
 
-1. Authenticate and Authorize with Spotify using the Spotify authentication service: 
-   `python3 application/spotify_authentication/api_authorization_web_service.py`
-2. Start up the rest of the application components: `docker compose up`
+```
+requests_factory ──► Requests exchange ──► api_call_engine ──► Spotify Web API
+   (seeds a crawl)      (RabbitMQ)         (GET, retry/backoff)      │
+                                                                     ▼
+                                              Responses exchange (fan-out ×4, RabbitMQ)
+                                                                     │
+            ┌────────────────────┬───────────────────┬──────────────┴────────┐
+            ▼                    ▼                   ▼                        ▼
+      write_to_disk        write_to_neo4j       follow_links            write_to_sqlite
+      (JSON cache)         (graph insert)     (re-queues URLs)            (stub, off)
+                                                     │
+                                                     └──► back to Requests exchange
+                                                          (recursive crawl, depth-limited)
+```
+
+- **Graph model:** `Track`, `Album`, `Artist`, `Genre` nodes; `CONTAINS`,
+  `CREATED`, `SPOTIFY_CLASSIFIED_AS` relationships. Everything is `MERGE`d on
+  stable Spotify IDs, so re-crawling is idempotent.
+- **Dedup:** every outbound request flows through one choke point
+  (`requests_factory.request_url`) and is checked against a durable Redis set, so
+  redundant follow requests don't flood the API (and trip rate limits).
+
+## Prerequisites
+
+- **Docker Desktop** (running).
+- **Neo4j Desktop** with a database running (`bolt://127.0.0.1:7687`). The crawler
+  connects to it from inside Docker via `host.docker.internal`. _(Alternatively,
+  run Neo4j fully in Docker — see the commented `neo4j` service in
+  `compose.yaml`.)_
+- **A registered Spotify app** (https://developer.spotify.com/dashboard) with:
+  - the **redirect URI `http://127.0.0.1:8000/callback`** registered (Spotify
+    rejects `localhost` as insecure — it must be the loopback IP).
+  - its client ID and secret available for `secrets/` (below).
+
+## Setup
+
+Populate `secrets/` (all gitignored):
+
+| File | Contents |
+|------|----------|
+| `secrets/spotify_client_id.secret` | your Spotify app client ID |
+| `secrets/spotify_client_secret.secret` | your Spotify app client secret |
+| `secrets/neo4j_credentials.yaml` | `username: neo4j` / `password: <your Neo4j Desktop password>` |
+
+The OAuth token files are written here automatically by the auth flow.
+
+## Run
+
+```bash
+docker compose up
+```
+
+What happens, in one command:
+1. RabbitMQ, Redis, and the response workers start.
+2. The **bundled Spotify auth service** serves a login page and the pipeline
+   **waits** (a token healthcheck gates it) until you authorize.
+3. Open **http://127.0.0.1:8000/login**, log into Spotify, click **Agree**. The
+   callback writes your tokens to `secrets/`.
+4. The healthcheck flips green, the gate releases, and the crawl of your Liked
+   Songs begins — writing JSON to `data/responses/` and the graph to Neo4j.
+
+## Configuration (`application/config.py`, all env-overridable)
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `CRAWL_LIKED_SONGS` | `True` | crawl your saved tracks |
+| `DEPTH_OF_SEARCH` | `1` | how far to follow neighbors |
+| `CRAWLED_URL_DEDUP` | `True` | skip already-requested URLs (Redis) |
+| `RESET_CRAWL` | `False` | clear the dedup set for a fresh crawl (set `true` to re-crawl from scratch) |
+| `USE_BATCH_ENDPOINTS` | `False` | use Spotify's `?ids=` batch endpoints (~22× fewer calls) — see note below |
+| `NEO4J_HOSTNAME` / `REDIS_HOSTNAME` / `RABBITMQ_HOSTNAME` | service names | point at host vs container services |
+
+> **Batch endpoints:** Spotify postponed (not cancelled) removing the multi-id
+> `?ids=` endpoints for existing apps. Verify with `_probe_batch_endpoints.py`
+> before enabling; the per-item path is the safe default.
+
+## Monitoring
+
+- **RabbitMQ Management UI — http://localhost:15672** (`guest`/`guest`): the
+  Queues tab shows per-stage backlog and live message rates. The crawl is done
+  when rates flatline to 0 and queues are empty.
+- **Logs:** `docker compose logs -f api_call_engine` (the live GET stream),
+  `docker compose logs -f responses_write_to_neo4j` (node/edge counts).
+- **Throughput pulse:** `docker compose logs --since 10s api_call_engine | grep -c 'GET:'` (0 = idle).
+- **Graph:** the Neo4j Desktop browser, e.g. `MATCH (a:Artist)-[:CREATED]->(t:Track) RETURN a,t LIMIT 100`.
+- **Disk cache:** `find data/responses -name '*.json' | wc -l`.
+
+## Tests
+
+```bash
+docker compose run --rm tests
+```
+
+A pytest suite (unit + integration) that brings up RabbitMQ + Redis and targets
+the host Neo4j Desktop; integration tests skip if a service is down.
+
+## Stack
+
+Python 3.13 · Poetry 2.4 · RabbitMQ 4 · Redis 8 · Neo4j 6 (driver) · Falcon 4 ·
+pika · pandas 3.
+
+## More
+
+- **Roadmap & status:** [ROADMAP.md](ROADMAP.md)
+- **Design notes (mock Spotify service, AWS):** [docs/](docs/)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,6 +116,17 @@ requests_factory ──► Requests exchange ──► api_call_engine ──►
 - [ ] CI (build + lint + smoke test).
 - [ ] Deploy target (managed RabbitMQ + Neo4j Aura + container host).
 
+### Stage 6 — Mock Spotify service (testing + AWS) _(planned)_
+A controllable facade of the Spotify API that can inject rate limiting / failures
+between successful fetches. Unlocks the resilience + E2E + scale tests that
+fixtures can't reach (the 429-cap, token-refresh, and dedup-rollback-on-500
+paths), and doubles as a first AWS workload that informs the real migration.
+**Design + phased plan: [docs/mock-spotify-service.md](docs/mock-spotify-service.md).**
+- [ ] Phase 0: configurable Spotify base URLs (env-overridable; mock emits self-referential hrefs).
+- [ ] Phase 1: local FastAPI mock + deterministic catalog as a Compose service; E2E / pagination / scale tests.
+- [ ] Phase 2: failure-injection control plane; the resilience tests.
+- [ ] Phase 3+: deploy to Fargate; inform the real-app AWS migration.
+
 ---
 
 ## 4. File map

--- a/docs/mock-spotify-service.md
+++ b/docs/mock-spotify-service.md
@@ -1,0 +1,159 @@
+# Design notes: a mock Spotify service (testing + AWS)
+
+_Status: idea / planning. Not yet built. Captured 2026-06-21._
+
+A controllable **facade of the Spotify Web API** the crawler depends on, that can
+**inject rate limiting / failures between successful fetches**. Two payoffs:
+
+1. **Testing** — makes the whole pipeline hermetically, deterministically
+   testable, including the resilience paths that fixtures can't reach.
+2. **AWS** — a safe, self-hosted target that doubles as a first AWS workload and
+   informs the eventual production migration of the real app.
+
+---
+
+## 1. Why this is the high-value next step for test coverage
+
+The current suite (`tests/`) covers logic against static fixtures and the
+backing services (Redis/RabbitMQ/Neo4j). What it **cannot** exercise today is the
+Spotify side and, crucially, the failure/resilience behavior — which is exactly
+where the real bugs were:
+
+| Behavior | Currently testable? | With the mock |
+|---|---|---|
+| 429 backoff cap (the 24h-freeze bug, review #5) | ✗ (needs a 429 with a punitive `Retry-After`) | inject a 429 + `Retry-After`, assert the cap + retry |
+| Token refresh on 401 (the infinite-refresh bug) | ✗ (needs a live token expiry) | inject a 401 after N calls, assert refresh + token re-read + resume |
+| **Dedup rollback on 500-exhaustion (review #1, HIGH)** | ✗ ("crafted fixtures do not exercise the retry-exhaustion path") | inject persistent 500s for a URL, assert it's un-marked + re-crawlable |
+| Full crawl → graph (E2E) | ✗ (no Spotify) | seed → mock → assert Neo4j == synthetic catalog |
+| Pagination (`next` chain) | ✗ | multi-page catalog, assert full traversal |
+| Dedup at scale / batch call reduction | ✗ (would hit the real rate limit) | 12k synthetic catalog, assert ~22× fewer calls, no wall |
+| Batch vs single equivalence | partial (fixtures) | crawl with `USE_BATCH_ENDPOINTS` on/off, assert identical graph |
+
+So the mock is the unlock for the **second tier** of testing (E2E, resilience,
+scale) on top of the unit/integration tier already in place.
+
+---
+
+## 2. What it implements (the crawler's surface, per Spotify's docs)
+
+**Phase 1 (happy path):**
+- Auth facade (`accounts.spotify.com`): `POST /api/token` for the
+  `authorization_code` and `refresh_token` grants → returns a fake
+  `access_token` / `refresh_token` / `expires_in`. (`GET /authorize` can short-
+  circuit to the callback with a fake `code`, or be skipped in test mode.)
+- API facade (`api.spotify.com`):
+  - `GET /v1/me/tracks?offset=&limit=` — paginated liked songs with a `next` link.
+  - `GET /v1/tracks/{id}`, `/v1/albums/{id}`, `/v1/artists/{id}`.
+  - `GET /v1/tracks?ids=`, `/v1/albums?ids=`, `/v1/artists?ids=` — batch; honor
+    the 50/20/50 caps and return `null` for unknown ids (real behavior the batch
+    handler already filters).
+
+**Phase 2 (deeper crawl, mirrors the unimplemented handlers):**
+`/v1/me/playlists`, `/v1/me/following`, `/v1/albums/{id}/tracks`,
+`/v1/artists/{id}/albums`.
+
+Response **shapes must match real Spotify** (the fields the handlers/Cypher
+consume), reflecting the current post-Feb-2026 field set.
+
+---
+
+## 3. The deterministic synthetic catalog
+
+A seeded generator builds an internally-consistent graph:
+- N liked songs over a smaller pool of artists/albums, with **realistic sharing**
+  (the same album/artist recurs across songs) so dedup and batching actually
+  matter.
+- Every referenced id resolves: a liked song's `album.id` is fetchable at
+  `/albums/{id}` and via the batch endpoint; artists likewise.
+- Parametrizable size: 10 songs for a fast E2E test, 12k for a scale test.
+- Deterministic from `(seed, size)` so assertions are exact and reproducible.
+
+**Gotcha to bake in:** the crawler follows the *absolute* `href`/`next` URLs in
+responses. So the mock must emit **self-referential** hrefs (pointing at its own
+base URL), or the engine will follow them to real Spotify. The mock generates
+hrefs from its configured public base URL.
+
+---
+
+## 4. Failure / rate-limit injection (the defining feature)
+
+A small **control plane** to set the mock's behavior per run, e.g.
+`POST /_control/config`:
+- `rate_limit_after_n` → return `429` with a chosen `Retry-After` after N
+  successful responses, then resume (models the real 24h penalty).
+- `rate_limit_probability` → p chance of `429` per request.
+- `token_expiry_after_n` → return `401` after N requests, forcing a refresh.
+- `server_error_burst` → inject `500`s (up to / beyond the retry cap) to exercise
+  the dedup-rollback give-up path.
+- `latency_ms` → injected delay, for timeout/throughput behavior.
+
+State (counters, config) is per-token or global. A test sets a mode, runs the
+crawl, and asserts the crawler's response (backoff, refresh, rollback, eventual
+completion or graceful give-up).
+
+---
+
+## 5. Architecture — local and AWS (one image, two homes)
+
+**Recommended: a containerized HTTP app (FastAPI/Flask), the same image run
+locally and on AWS.** This fits the "Dockerize everything" preference: it runs as
+a Compose `spotify_mock` service for tests *and* deploys unchanged to AWS.
+
+- **Local:** Compose service `spotify_mock`; the crawler points at it via
+  configurable base URLs (see §6). The test suite gets a `spotify_mock` fixture.
+- **AWS:** the same image on **ECS/Fargate behind an ALB** (or App Runner).
+  In-memory deterministic data needs no datastore; if multi-instance state is
+  wanted, back the control config + counters with DynamoDB or ElastiCache.
+
+Alternative: **API Gateway + Lambda** (per-endpoint Lambdas, DynamoDB for
+state). More AWS-native and scales to zero, but harder to run identically
+locally (SAM/LocalStack) — less aligned with the container-everywhere approach.
+The containerized option is the recommendation; the Lambda option is the
+fallback if a serverless cost profile is preferred.
+
+---
+
+## 6. Prerequisite refactor (small, env-overridable — matches the existing pattern)
+
+Make the Spotify base URLs configurable (today they're hard-coded to
+`https://api.spotify.com` / `https://accounts.spotify.com`):
+- `SPOTIFY_API_BASE_URL` (default `https://api.spotify.com`)
+- `SPOTIFY_ACCOUNTS_BASE_URL` (default `https://accounts.spotify.com`)
+
+Touch points: `requests_factory` (URL construction + `request_batch`),
+`api_call_engine` (it follows absolute hrefs/next — so this works *as long as the
+mock emits self-referential hrefs*, §3), the OAuth web service, and
+`refresh_token`. This mirrors the existing `RABBITMQ_HOSTNAME` / `NEO4J_HOSTNAME`
+env-override pattern, so it's a clean, low-risk change — and it's the one thing
+that must land before the mock is useful.
+
+---
+
+## 7. Phased plan
+
+- **Phase 0 — prereq:** configurable base URLs; confirm the engine follows the
+  mock's self-referential hrefs. (Small.)
+- **Phase 1 — local mock + happy path:** FastAPI container, deterministic
+  catalog, Phase-1 endpoints; add a `spotify_mock` Compose service + test
+  fixture. Unlocks E2E + pagination + scale tests, fully Dockerized.
+- **Phase 2 — failure injection:** the control plane (§4). Unlocks the resilience
+  tests (429 cap, token refresh, dedup rollback) — the highest-value coverage.
+- **Phase 3 — deploy to AWS (Fargate):** the mock becomes a load-test target and
+  an AWS spike (ALB, task def, IaC).
+- **Phase 4 — real-app AWS migration, informed by the above:** map the pipeline
+  to managed services — workers → ECS/Fargate (or Lambda), RabbitMQ → Amazon MQ
+  or SQS, Neo4j → Neo4j Aura, Redis → ElastiCache, secrets → Secrets Manager,
+  OAuth tokens → per-user storage (ties into the Stage 4 multi-user work).
+
+---
+
+## 8. Why it's worth it
+
+- Turns the three scariest, currently-untestable failure modes into push-button
+  regression tests — before they bite again in production.
+- Lets the crawler be developed, CI-tested, and demoed with **no real Spotify app,
+  no OAuth, no rate limits**.
+- The rate-limit facade is exactly how you'd validate production resilience
+  before pointing the AWS deployment at the real (rate-limited) Spotify.
+- Building the mock on AWS de-risks the real migration: same primitives (Fargate,
+  ALB, IaC, DynamoDB/ElastiCache) on a throwaway workload first.


### PR DESCRIPTION
Two onboarding deliverables so the project can be handed to a human or an agent cold:

- **README** rewritten for the current single-`docker compose up` flow (architecture, prereqs, the 127.0.0.1 OAuth handoff, config flags, monitoring, tests, stack versions).
- **`.claude/skills/spin-up/SKILL.md`** — an agent runbook for set up / run / monitor locally, capturing the human-in-the-loop OAuth step and every gotcha from today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)