### PR TITLE
feat(config): configurable Spotify base URLs (mock-service Phase 0)

### DIFF
--- a/application/config.py
+++ b/application/config.py
@@ -62,3 +62,11 @@ USE_BATCH_ENDPOINTS = _env_bool('USE_BATCH_ENDPOINTS', False)
 # Clear the Redis crawled-URL set at crawl start for a fresh run. Default off so
 # the dedup set persists across runs (resume); set RESET_CRAWL=true to start clean.
 RESET_CRAWL = _env_bool('RESET_CRAWL', False)
+
+###
+# Spotify endpoints — override to point the crawler at a local mock service.
+# (A mock must emit self-referential hrefs/next using its own base URL, since
+# the engine follows the absolute URLs in responses.)
+###
+SPOTIFY_API_BASE_URL = os.environ.get('SPOTIFY_API_BASE_URL', 'https://api.spotify.com')
+SPOTIFY_ACCOUNTS_BASE_URL = os.environ.get('SPOTIFY_ACCOUNTS_BASE_URL', 'https://accounts.spotify.com')

--- a/application/requests_factory.py
+++ b/application/requests_factory.py
@@ -7,6 +7,7 @@ from application.config import (
     CRAWLED_URL_DEDUP,
     DEPTH_OF_SEARCH,
     RESET_CRAWL,
+    SPOTIFY_API_BASE_URL,
 )
 from application.cache.redis_client import url_is_new, unmark_url, reset_crawled_set
 from application.message_queue.connect import connect_to_rabbitmq_exchange, publish_message_to_exchange
@@ -81,7 +82,7 @@ class SpotifyRequestFactory:
         for start in range(0, len(unique_ids), limit):
             chunk = unique_ids[start:start + limit]
             cls.request_url(
-                url=f"https://api.spotify.com/v1/{resource_type}?ids={','.join(chunk)}",
+                url=f"{SPOTIFY_API_BASE_URL}/v1/{resource_type}?ids={','.join(chunk)}",
                 depth_of_search=depth_of_search,
             )
 
@@ -89,7 +90,7 @@ class SpotifyRequestFactory:
     def request_liked_songs_first_page(cls, depth_of_search):
         logger.info(f'STARTING FETCH OF LIKED SONGS')
         return cls.request_url(
-            url="https://api.spotify.com/v1/me/tracks",
+            url=f"{SPOTIFY_API_BASE_URL}/v1/me/tracks",
             depth_of_search=depth_of_search
         )
 
@@ -97,7 +98,7 @@ class SpotifyRequestFactory:
     def request_followed_playlists_first_page(cls, depth_of_search):
         logger.info(f'STARTING FETCH OF FOLLOWED_PLAYLISTS')
         return cls.request_url(
-            url="https://api.spotify.com/v1/me/playlists",
+            url=f"{SPOTIFY_API_BASE_URL}/v1/me/playlists",
             depth_of_search=depth_of_search
         )
 
@@ -105,7 +106,7 @@ class SpotifyRequestFactory:
     def request_followed_artists_first_page(cls, depth_of_search):
         logger.info(f'STARTING FETCH OF FOLLOWED_ARTISTS')
         return cls.request_url(
-            url="https://api.spotify.com/v1/me/following?type=artist",
+            url=f"{SPOTIFY_API_BASE_URL}/v1/me/following?type=artist",
             depth_of_search=depth_of_search
         )
 

--- a/application/response_handlers/albums/single_album.py
+++ b/application/response_handlers/albums/single_album.py
@@ -1,4 +1,4 @@
-from application.config import APPLICATION_DIR, DATA_DIR, SECRETS_DIR, USE_BATCH_ENDPOINTS
+from application.config import APPLICATION_DIR, DATA_DIR, SECRETS_DIR, USE_BATCH_ENDPOINTS, SPOTIFY_API_BASE_URL
 from application.graph_database.connect import execute_query_against_neo4j
 from application.loggers import get_logger
 from application.requests_factory import SpotifyRequestFactory
@@ -15,7 +15,7 @@ class GetSingleAlbumResponseHandler(BaseResponseHandler):
     Docs: https://developer.spotify.com/documentation/web-api/reference/get-an-album
     """
 
-    URL_PATTERN = "https://api.spotify.com/v1/albums"
+    URL_PATTERN = f"{SPOTIFY_API_BASE_URL}/v1/albums"
     DISK_LOCATION = DATA_DIR / "responses" / "albums"
 
     with open(GRAPH_DATABASE_QUERIES_DIR / "insert_single_album.cypher", "r") as f:

--- a/application/response_handlers/artists/single_artist.py
+++ b/application/response_handlers/artists/single_artist.py
@@ -1,4 +1,4 @@
-from application.config import APPLICATION_DIR, DATA_DIR, SECRETS_DIR
+from application.config import APPLICATION_DIR, DATA_DIR, SECRETS_DIR, SPOTIFY_API_BASE_URL
 from application.graph_database.connect import execute_query_against_neo4j
 from application.loggers import get_logger
 from application.response_handlers.base_handler import BaseResponseHandler
@@ -14,7 +14,7 @@ class GetSingleArtistResponseHandler(BaseResponseHandler):
     Docs: https://developer.spotify.com/documentation/web-api/reference/get-an-artist
     """
 
-    URL_PATTERN = "https://api.spotify.com/v1/artists"
+    URL_PATTERN = f"{SPOTIFY_API_BASE_URL}/v1/artists"
     DISK_LOCATION = DATA_DIR / "responses" / "artists"
 
     with open(GRAPH_DATABASE_QUERIES_DIR / "insert_single_artist.cypher", "r") as f:

--- a/application/response_handlers/main.py
+++ b/application/response_handlers/main.py
@@ -2,7 +2,7 @@ import argparse
 from json import loads
 from urllib.parse import urlparse, parse_qs
 
-from application.config import SECRETS_DIR
+from application.config import SECRETS_DIR, SPOTIFY_API_BASE_URL
 from application.graph_database.connect import connect_to_neo4j
 from application.graph_database.initialize_database_environment import (
     initialize_database_environment as initialize_neo4j_environment
@@ -77,7 +77,7 @@ class SpotifyResponseController:
         normalized = parsed._replace(
             netloc=parsed.netloc.split(":")[0], query="", fragment=""
         )
-        if not request_url.startswith("https://api.spotify.com/v1/me"):
+        if not request_url.startswith(f"{SPOTIFY_API_BASE_URL}/v1/me"):
             normalized = normalized._replace(path=normalized.path.rsplit("/", maxsplit=1)[0])
         try:
             return cls.RESPONSE_HANDLER_URL_MAPPING[normalized.geturl()]

--- a/application/response_handlers/me/my_liked_songs.py
+++ b/application/response_handlers/me/my_liked_songs.py
@@ -1,6 +1,6 @@
 import pandas
 
-from application.config import APPLICATION_DIR, DATA_DIR, SECRETS_DIR, USE_BATCH_ENDPOINTS
+from application.config import APPLICATION_DIR, DATA_DIR, SECRETS_DIR, USE_BATCH_ENDPOINTS, SPOTIFY_API_BASE_URL
 from application.graph_database.connect import execute_query_against_neo4j
 from application.loggers import get_logger
 from application.requests_factory import SpotifyRequestFactory
@@ -17,7 +17,7 @@ class LikedSongsPlaylistResponseHandler(BaseResponseHandler):
     Docs: https://developer.spotify.com/documentation/web-api/reference/get-users-saved-tracks
     """
 
-    URL_PATTERN = "https://api.spotify.com/v1/me/tracks"
+    URL_PATTERN = f"{SPOTIFY_API_BASE_URL}/v1/me/tracks"
     DISK_LOCATION = DATA_DIR / "responses" / "liked_songs"
 
     with open(GRAPH_DATABASE_QUERIES_DIR / "insert_batch_of_liked_songs.cypher", "r") as f:

--- a/application/response_handlers/tracks/single_track.py
+++ b/application/response_handlers/tracks/single_track.py
@@ -1,4 +1,4 @@
-from application.config import APPLICATION_DIR, DATA_DIR, SECRETS_DIR, USE_BATCH_ENDPOINTS
+from application.config import APPLICATION_DIR, DATA_DIR, SECRETS_DIR, USE_BATCH_ENDPOINTS, SPOTIFY_API_BASE_URL
 from application.graph_database.connect import execute_query_against_neo4j
 from application.loggers import get_logger
 from application.requests_factory import SpotifyRequestFactory
@@ -15,7 +15,7 @@ class GetSingleTrackResponseHandler(BaseResponseHandler):
     Docs: https://developer.spotify.com/documentation/web-api/reference/get-track
     """
 
-    URL_PATTERN = "https://api.spotify.com/v1/tracks"
+    URL_PATTERN = f"{SPOTIFY_API_BASE_URL}/v1/tracks"
     DISK_LOCATION = DATA_DIR / "responses" / "tracks"
 
     with open(GRAPH_DATABASE_QUERIES_DIR / "insert_single_track.cypher", "r") as f:

--- a/application/spotify_authentication/api_authorization_web_service.py
+++ b/application/spotify_authentication/api_authorization_web_service.py
@@ -5,7 +5,7 @@ from wsgiref.simple_server import make_server
 import falcon
 import requests
 
-from application.config import SECRETS_DIR
+from application.config import SECRETS_DIR, SPOTIFY_ACCOUNTS_BASE_URL
 
 SPOTIFY_CLIENT_ID_FILE = SECRETS_DIR / "spotify_client_id.secret"
 SPOTIFY_CLIENT_SECRET_FILE = SECRETS_DIR / "spotify_client_secret.secret"
@@ -36,7 +36,7 @@ class SpotifyLoginResource:
                                   "scope": scopes,
                                   "redirect_uri": SPOTIFY_REDIRECT_URI})
 
-        authorization_code_uri = f'https://accounts.spotify.com/authorize?{query_params}'
+        authorization_code_uri = f'{SPOTIFY_ACCOUNTS_BASE_URL}/authorize?{query_params}'
         raise falcon.HTTPMovedPermanently(authorization_code_uri)
 
 
@@ -56,7 +56,7 @@ class SpotifyAuthCodeResource:
         print("Requesting API Token from Spotify...")
 
         r = requests.post(
-            'https://accounts.spotify.com/api/token',
+            f'{SPOTIFY_ACCOUNTS_BASE_URL}/api/token',
             data={
                 "code": authorization_code,
                 "redirect_uri": SPOTIFY_REDIRECT_URI,

--- a/application/spotify_authentication/refresh_token.py
+++ b/application/spotify_authentication/refresh_token.py
@@ -1,6 +1,6 @@
 import requests
 
-from application.config import SECRETS_DIR
+from application.config import SECRETS_DIR, SPOTIFY_ACCOUNTS_BASE_URL
 
 SPOTIFY_CLIENT_ID_FILE = SECRETS_DIR / "spotify_client_id.secret"
 SPOTIFY_API_TOKEN_FILE = SECRETS_DIR / "spotify_api_token.secret"
@@ -12,7 +12,7 @@ def refresh_spotify_auth():
     with open(SPOTIFY_REFRESH_TOKEN_FILE, "r") as f:
         refresh_token = f.read()
 
-    r = requests.post('https://accounts.spotify.com/api/token',
+    r = requests.post(f'{SPOTIFY_ACCOUNTS_BASE_URL}/api/token',
                       data={
                           "grant_type": 'refresh_token',
                           "refresh_token": refresh_token

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,3 +24,9 @@ def test_shipped_flag_defaults():
     assert config.CRAWLED_URL_DEDUP is True
     assert config.USE_BATCH_ENDPOINTS is False
     assert config.RESET_CRAWL is False
+
+
+def test_spotify_base_url_defaults():
+    # Default to the real Spotify; override (e.g. to a local mock) is env-driven.
+    assert config.SPOTIFY_API_BASE_URL == "https://api.spotify.com"
+    assert config.SPOTIFY_ACCOUNTS_BASE_URL == "https://accounts.spotify.com"


### PR DESCRIPTION
Prerequisite for the local mock: `SPOTIFY_API_BASE_URL` / `SPOTIFY_ACCOUNTS_BASE_URL` (default real Spotify), threaded through the crawl seeds + batch URLs, the OAuth authorize/token calls, the handlers' `URL_PATTERN` (response routing), and the dispatcher's `/v1/me` check. Defaults unchanged; **35 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)