### PR TITLE
feat: local mock Spotify service + tests + skill (Phase 1)

### DIFF
--- a/.claude/skills/spin-up/SKILL.md
+++ b/.claude/skills/spin-up/SKILL.md
@@ -108,8 +108,41 @@ d.close()"
 ## 6. Tests
 
 ```bash
-docker compose run --rm tests        # pytest; brings up rabbitmq+redis, neo4j tests use the host Desktop
+docker compose run --rm tests        # pytest; brings up rabbitmq+redis+spotify_mock, neo4j tests use the host Desktop
 ```
+
+## Mock Spotify service — crawl offline, no real Spotify
+
+`mock_spotify/` is a controllable Falcon facade of the Spotify API (profile-gated
+`spotify_mock` compose service on :80, with a deterministic synthetic catalog and
+self-referential hrefs). Use it to crawl with **no OAuth, no rate limits, and
+reproducible data** — ideal for testing and demos. It's brought up automatically
+by `docker compose run --rm tests`.
+
+**Run the full pipeline against the mock** (no browser/OAuth step needed):
+```bash
+echo -n mock-access-token  > secrets/spotify_api_token.secret     # seed a fake token
+echo -n mock-refresh-token > secrets/spotify_refresh_token.secret # (satisfies the auth gate)
+RESET_CRAWL=true docker compose -f compose.yaml -f docker-compose.mock.yml up
+```
+The crawler hits the mock's self-referential URLs and builds the graph in Neo4j,
+fully offline. Monitor exactly as in section 5.
+
+**Inject failures** to exercise resilience (control plane lives on the mock):
+```bash
+# next request 429s with Retry-After 5, then resumes:
+docker compose exec spotify_mock curl -s -XPOST localhost:80/_control/config \
+  -H 'Content-Type: application/json' -d '{"fail_next_n":1,"fail_status":429,"retry_after":5}'
+# a specific URL always 500s (exercises the dedup-rollback give-up path):
+docker compose exec spotify_mock curl -s -XPOST localhost:80/_control/config \
+  -H 'Content-Type: application/json' -d '{"fail_url_substring":"trk000005","fail_status":500}'
+docker compose exec spotify_mock curl -s -XPOST localhost:80/_control/reset    # clear injection
+```
+`fail_status`: `429` (set `retry_after`) | `401` | `500`. Scale the catalog via env
+on the `spotify_mock` service: `MOCK_N_TRACKS` / `MOCK_N_ALBUMS` / `MOCK_N_ARTISTS`.
+
+**Design + roadmap:** `docs/mock-spotify-service.md` (Phase 0/1 done locally; the
+AWS/Fargate deploy is Phase 3, not yet built).
 
 ## 7. Tear down
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -168,6 +168,23 @@ services:
       - redis
     command: bash -c "sleep 5 && python3 application/requests_factory.py"
 
+  spotify_mock:
+    image: "spotify-power-browser:latest"
+    # A controllable mock of the Spotify Web API, for tests and mock-backed runs.
+    # Not part of the normal `up` (profile-gated). Listens on :80 so request URLs
+    # carry no port (the dispatcher strips ports). The crawler reaches it at
+    # http://spotify_mock — set SPOTIFY_API_BASE_URL=http://spotify_mock to crawl it.
+    profiles: ["test", "mock"]
+    volumes:
+      - "./mock_spotify:/src/mock_spotify"
+    command: python3 -m mock_spotify.app
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:80/_control/health || exit 1"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 3s
+
   tests:
     image: "spotify-power-browser:latest"
     # Test runner -- not part of the normal `up`. Run with:
@@ -186,6 +203,8 @@ services:
       rabbitmq:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      spotify_mock:
         condition: service_healthy
     command: python3 -m pytest tests/
 

--- a/docker-compose.mock.yml
+++ b/docker-compose.mock.yml
@@ -1,0 +1,44 @@
+# Override: point the whole crawl pipeline at the local mock Spotify service.
+#
+# Usage (seed a fake token first so the auth gate passes, then bring it up):
+#   echo -n mock-access-token  > secrets/spotify_api_token.secret
+#   echo -n mock-refresh-token > secrets/spotify_refresh_token.secret
+#   RESET_CRAWL=true docker compose -f compose.yaml -f docker-compose.mock.yml up
+#
+# The crawler then hits the mock's self-referential URLs and builds the graph in
+# Neo4j — fully offline, no real Spotify, no OAuth, no rate limits.
+services:
+  # Include the mock in a normal `up` (it's profile-gated in the base file).
+  spotify_mock:
+    profiles: []
+
+  requests_factory_start_crawls:
+    environment:
+      SPOTIFY_API_BASE_URL: http://spotify_mock
+      SPOTIFY_ACCOUNTS_BASE_URL: http://spotify_mock
+
+  api_call_engine:
+    environment:
+      SPOTIFY_API_BASE_URL: http://spotify_mock
+      SPOTIFY_ACCOUNTS_BASE_URL: http://spotify_mock
+
+  responses_write_to_disk:
+    environment:
+      SPOTIFY_API_BASE_URL: http://spotify_mock
+      SPOTIFY_ACCOUNTS_BASE_URL: http://spotify_mock
+
+  responses_write_to_neo4j:
+    environment:
+      # base file already sets NEO4J_HOSTNAME here; compose merges environment.
+      SPOTIFY_API_BASE_URL: http://spotify_mock
+      SPOTIFY_ACCOUNTS_BASE_URL: http://spotify_mock
+
+  responses_follow_links:
+    environment:
+      SPOTIFY_API_BASE_URL: http://spotify_mock
+      SPOTIFY_ACCOUNTS_BASE_URL: http://spotify_mock
+
+  spotify_authentication:
+    environment:
+      SPOTIFY_API_BASE_URL: http://spotify_mock
+      SPOTIFY_ACCOUNTS_BASE_URL: http://spotify_mock

--- a/mock_spotify/__init__.py
+++ b/mock_spotify/__init__.py
@@ -1,0 +1,1 @@
+"""A controllable mock of the Spotify Web API (testing + local dev)."""

--- a/mock_spotify/app.py
+++ b/mock_spotify/app.py
@@ -1,0 +1,147 @@
+"""A mock Spotify Web API: a controllable facade of the endpoints the crawler
+uses, with a failure-injection control plane.
+
+Endpoints (api.spotify.com facade):
+  GET  /v1/me/tracks?offset=&limit=     paginated saved tracks (self-referential next)
+  GET  /v1/{tracks,albums,artists}/{id} single resource (404 if unknown)
+  GET  /v1/{tracks,albums,artists}?ids= batch (null for unknown ids)
+Auth (accounts.spotify.com facade):
+  POST /api/token                       fake token (authorization_code / refresh_token)
+  GET  /authorize                       redirect to the callback with a fake code
+Control plane:
+  POST /_control/config                 inject failures (see FailureInjectionMiddleware)
+  POST /_control/reset                  clear injection
+  GET  /_control/health                 200 (compose healthcheck)
+"""
+import json
+from socketserver import ThreadingMixIn
+from wsgiref.simple_server import make_server, WSGIServer
+
+import falcon
+
+from mock_spotify import catalog
+
+# Mutable injection state, driven by POST /_control/config.
+INJECTION = {
+    "fail_next_n": 0,            # next N (non-control) requests fail, then resume
+    "fail_url_substring": None,  # any request whose path contains this always fails
+    "fail_status": 429,          # 429 | 401 | 500
+    "retry_after": 0,            # Retry-After seconds for 429s
+}
+
+
+def _default_injection():
+    return {"fail_next_n": 0, "fail_url_substring": None, "fail_status": 429, "retry_after": 0}
+
+
+def _raise(status, retry_after):
+    if status == 429:
+        raise falcon.HTTPTooManyRequests(retry_after=int(retry_after))
+    if status == 401:
+        raise falcon.HTTPUnauthorized(title="The access token expired")
+    raise falcon.HTTPInternalServerError(title="mock injected 500")
+
+
+class FailureInjectionMiddleware:
+    def process_request(self, req, resp):
+        if req.path.startswith("/_control"):
+            return
+        sub = INJECTION["fail_url_substring"]
+        if sub and sub in req.path:
+            _raise(INJECTION["fail_status"], INJECTION["retry_after"])
+        if INJECTION["fail_next_n"] > 0:
+            INJECTION["fail_next_n"] -= 1
+            _raise(INJECTION["fail_status"], INJECTION["retry_after"])
+
+
+class LikedSongsResource:
+    def on_get(self, req, resp):
+        offset = req.get_param_as_int("offset", default=0)
+        limit = req.get_param_as_int("limit", default=20)
+        resp.media = catalog.liked_songs_page(offset, limit)
+
+
+class SingleResource:
+    def __init__(self, resource_type):
+        self.resource_type = resource_type
+
+    def on_get(self, req, resp, resource_id):
+        obj = catalog.get_by_id(self.resource_type, resource_id)
+        if obj is None:
+            raise falcon.HTTPNotFound()
+        resp.media = obj
+
+
+class BatchResource:
+    def __init__(self, resource_type):
+        self.resource_type = resource_type
+
+    def on_get(self, req, resp):
+        ids = (req.get_param("ids") or "").split(",")
+        resp.media = {self.resource_type: [catalog.get_by_id(self.resource_type, i) for i in ids if i]}
+
+
+class TokenResource:
+    def on_post(self, req, resp):
+        resp.media = {
+            "access_token": "mock-access-token",
+            "token_type": "Bearer",
+            "scope": "user-library-read",
+            "expires_in": 3600,
+            "refresh_token": "mock-refresh-token",
+        }
+
+
+class AuthorizeResource:
+    def on_get(self, req, resp):
+        redirect_uri = req.get_param("redirect_uri", default="http://127.0.0.1:8000/callback")
+        raise falcon.HTTPSeeOther(f"{redirect_uri}?code=mock-auth-code")
+
+
+class ControlConfigResource:
+    def on_post(self, req, resp):
+        cfg = req.media or {}
+        for key in INJECTION:
+            if key in cfg:
+                INJECTION[key] = cfg[key]
+        resp.media = dict(INJECTION)
+
+
+class ControlResetResource:
+    def on_post(self, req, resp):
+        INJECTION.update(_default_injection())
+        resp.media = dict(INJECTION)
+
+
+class HealthResource:
+    def on_get(self, req, resp):
+        resp.media = {"status": "ok"}
+
+
+def create_app():
+    app = falcon.App(middleware=[FailureInjectionMiddleware()])
+    app.add_route("/v1/me/tracks", LikedSongsResource())
+    for rtype in ("tracks", "albums", "artists"):
+        app.add_route(f"/v1/{rtype}/{{resource_id}}", SingleResource(rtype))
+        app.add_route(f"/v1/{rtype}", BatchResource(rtype))
+    app.add_route("/api/token", TokenResource())
+    app.add_route("/authorize", AuthorizeResource())
+    app.add_route("/_control/config", ControlConfigResource())
+    app.add_route("/_control/reset", ControlResetResource())
+    app.add_route("/_control/health", HealthResource())
+    return app
+
+
+class _ThreadingWSGIServer(ThreadingMixIn, WSGIServer):
+    daemon_threads = True
+
+
+def serve(port=80):
+    with make_server("", port, create_app(), server_class=_ThreadingWSGIServer) as httpd:
+        print(f"Mock Spotify serving on :{port}")
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    import os
+    serve(int(os.environ.get("MOCK_PORT", "80")))

--- a/mock_spotify/catalog.py
+++ b/mock_spotify/catalog.py
@@ -1,0 +1,112 @@
+"""A deterministic, self-consistent synthetic Spotify catalog.
+
+Purely functional: any id reconstructs to a fixed object, so the same crawl is
+reproducible and every referenced id resolves. Albums/artists are shared across
+tracks (so dedup and batching actually matter). Object shapes match what the
+crawler's handlers + Cypher consume (see tests/conftest.py), and all hrefs are
+self-referential (point back at this mock) so the engine follows them here.
+"""
+import os
+
+# How the crawler reaches this mock (and what the hrefs must point at).
+PUBLIC_BASE_URL = os.environ.get("MOCK_PUBLIC_BASE_URL", "http://spotify_mock")
+
+# Catalog size (env-tunable for scale tests).
+N_TRACKS = int(os.environ.get("MOCK_N_TRACKS", "60"))
+N_ALBUMS = int(os.environ.get("MOCK_N_ALBUMS", "20"))
+N_ARTISTS = int(os.environ.get("MOCK_N_ARTISTS", "15"))
+
+
+def _n(prefix, identifier):
+    """Extract the integer suffix from an id like 'trk000007' -> 7, or None."""
+    if not isinstance(identifier, str) or not identifier.startswith(prefix):
+        return None
+    suffix = identifier[len(prefix):]
+    return int(suffix) if suffix.isdigit() else None
+
+
+def artist(i):
+    aid = f"art{i % N_ARTISTS:06d}"
+    return {
+        "uri": f"spotify:artist:{aid}",
+        "id": aid,
+        "name": f"Artist {i % N_ARTISTS}",
+        "external_urls": {"spotify": f"https://open.spotify.com/artist/{aid}"},
+        "href": f"{PUBLIC_BASE_URL}/v1/artists/{aid}",
+        "type": "artist",
+        "genres": [f"genre-{i % 5}"],
+    }
+
+
+def album(i):
+    alid = f"alb{i % N_ALBUMS:06d}"
+    # Two artists per album, derived from the album number (shared across tracks).
+    artists = [artist(i % N_ALBUMS), artist((i % N_ALBUMS) + 1)]
+    return {
+        "uri": f"spotify:album:{alid}",
+        "id": alid,
+        "name": f"Album {i % N_ALBUMS}",
+        "release_date": "2020-01-01",
+        "release_date_precision": "day",
+        "total_tracks": 10,
+        "album_type": "album",
+        "external_urls": {"spotify": f"https://open.spotify.com/album/{alid}"},
+        "href": f"{PUBLIC_BASE_URL}/v1/albums/{alid}",
+        "type": "album",
+        "artists": artists,
+        "genres": [],
+    }
+
+
+def track(i):
+    tid = f"trk{i:06d}"
+    return {
+        "uri": f"spotify:track:{tid}",
+        "id": tid,
+        "name": f"Track {i}",
+        "explicit": False,
+        "is_local": False,
+        "duration_ms": 200000,
+        "popularity": 50,
+        "type": "track",
+        "href": f"{PUBLIC_BASE_URL}/v1/tracks/{tid}",
+        "external_urls": {"spotify": f"https://open.spotify.com/track/{tid}"},
+        "album": album(i),          # track i lives on album (i % N_ALBUMS)
+        "artists": [artist(i)],     # plus its own performing artist
+    }
+
+
+def get_by_id(resource_type, identifier):
+    """Resolve a single resource by id, or None if it doesn't exist (Spotify
+    returns null for unknown ids on the batch endpoints)."""
+    if resource_type == "tracks":
+        n = _n("trk", identifier)
+        return track(n) if n is not None and 0 <= n < N_TRACKS else None
+    if resource_type == "albums":
+        n = _n("alb", identifier)
+        return album(n) if n is not None and 0 <= n < N_ALBUMS else None
+    if resource_type == "artists":
+        n = _n("art", identifier)
+        return artist(n) if n is not None and 0 <= n < N_ARTISTS else None
+    return None
+
+
+def liked_songs_page(offset, limit):
+    """A page of saved tracks with a self-referential `next` link (or null)."""
+    items = [
+        {"added_at": "2021-01-01T00:00:00Z", "track": track(i)}
+        for i in range(offset, min(offset + limit, N_TRACKS))
+    ]
+    next_offset = offset + limit
+    next_url = (
+        f"{PUBLIC_BASE_URL}/v1/me/tracks?offset={next_offset}&limit={limit}"
+        if next_offset < N_TRACKS else None
+    )
+    return {
+        "href": f"{PUBLIC_BASE_URL}/v1/me/tracks?offset={offset}&limit={limit}",
+        "items": items,
+        "limit": limit,
+        "offset": offset,
+        "next": next_url,
+        "total": N_TRACKS,
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,22 @@ def rabbitmq_channel():
 
 
 @pytest.fixture
+def mock_base():
+    """Base URL of the mock Spotify service; skips if it isn't reachable."""
+    import requests
+    base = "http://spotify_mock"
+    try:
+        requests.post(f"{base}/_control/reset", timeout=3).raise_for_status()
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"Mock Spotify service not reachable: {exc}")
+    yield base
+    try:
+        requests.post(f"{base}/_control/reset", timeout=3)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+@pytest.fixture
 def neo4j_driver():
     from application.config import SECRETS_DIR
     from application.graph_database.connect import connect_to_neo4j

--- a/tests/test_e2e_crawl.py
+++ b/tests/test_e2e_crawl.py
@@ -1,0 +1,48 @@
+"""End-to-end (data path): a real mock response → the real handler + Cypher →
+Neo4j. Needs both the mock service and Neo4j (skips otherwise)."""
+import requests
+
+from application.response_handlers.me.my_liked_songs import LikedSongsPlaylistResponseHandler
+
+
+def _all_uris(page):
+    uris = set()
+    for item in page["items"]:
+        track = item["track"]
+        uris.add(track["uri"])
+        uris.add(track["album"]["uri"])
+        for artist in track["album"]["artists"] + track["artists"]:
+            uris.add(artist["uri"])
+    return uris
+
+
+def test_mock_liked_songs_page_builds_the_graph(mock_base, neo4j_driver):
+    page = requests.get(f"{mock_base}/v1/me/tracks?offset=0&limit=5").json()
+    uris = _all_uris(page)
+    try:
+        LikedSongsPlaylistResponseHandler(f"{mock_base}/v1/me/tracks", 1, page).write_to_neo4j(driver=neo4j_driver)
+
+        # every track/album/artist the page referenced is now a node
+        recs, _, _ = neo4j_driver.execute_query(
+            "MATCH (n) WHERE n.uri IN $uris RETURN count(n) AS c", uris=list(uris))
+        assert recs[0]["c"] == len(uris)
+
+        # the Album-CONTAINS->Track edges exist
+        track_uris = [item["track"]["uri"] for item in page["items"]]
+        recs, _, _ = neo4j_driver.execute_query(
+            "MATCH (:Album)-[:CONTAINS]->(t:Track) WHERE t.uri IN $u RETURN count(DISTINCT t) AS c", u=track_uris)
+        assert recs[0]["c"] == len(track_uris)
+    finally:
+        neo4j_driver.execute_query("MATCH (n) WHERE n.uri IN $uris DETACH DELETE n", uris=list(uris))
+
+
+def test_follow_links_from_a_mock_page_points_back_at_the_mock(mock_base, monkeypatch):
+    page = requests.get(f"{mock_base}/v1/me/tracks?offset=0&limit=3").json()
+    captured = []
+    monkeypatch.setattr(
+        "application.requests_factory.SpotifyRequestFactory.request_url",
+        staticmethod(lambda url, depth_of_search=0: captured.append(url)),
+    )
+    LikedSongsPlaylistResponseHandler(f"{mock_base}/v1/me/tracks", 1, page).follow_links()
+    assert captured  # it followed track/album/artist hrefs
+    assert all(url.startswith(mock_base) for url in captured)  # self-referential, stays on the mock

--- a/tests/test_mock_service.py
+++ b/tests/test_mock_service.py
@@ -1,0 +1,58 @@
+"""Tests for the mock Spotify service itself (hit over HTTP via the
+`spotify_mock` compose service)."""
+import requests
+
+
+def test_health(mock_base):
+    assert requests.get(f"{mock_base}/_control/health").json()["status"] == "ok"
+
+
+def test_liked_songs_pagination_traverses_whole_catalog(mock_base):
+    seen, total = 0, None
+    url = f"{mock_base}/v1/me/tracks?offset=0&limit=20"
+    while url:
+        page = requests.get(url).json()
+        total = page["total"]
+        seen += len(page["items"])
+        assert page["items"][0]["track"]["href"].startswith(mock_base)  # self-referential
+        url = page["next"]
+    assert seen == total  # the whole catalog was reachable via `next`
+
+
+def test_single_resources_resolve(mock_base):
+    for rtype, prefix in [("tracks", "trk"), ("albums", "alb"), ("artists", "art")]:
+        obj = requests.get(f"{mock_base}/v1/{rtype}/{prefix}000000").json()
+        assert obj["id"] == f"{prefix}000000"
+        assert obj["href"].startswith(mock_base)
+
+
+def test_unknown_single_is_404(mock_base):
+    assert requests.get(f"{mock_base}/v1/tracks/does-not-exist").status_code == 404
+
+
+def test_batch_returns_objects_and_nulls_for_unknown(mock_base):
+    tracks = requests.get(f"{mock_base}/v1/tracks?ids=trk000000,unknownid,trk000001").json()["tracks"]
+    assert [t and t["id"] for t in tracks] == ["trk000000", None, "trk000001"]
+
+
+def test_token_endpoint(mock_base):
+    body = requests.post(f"{mock_base}/api/token", data={"grant_type": "refresh_token"}).json()
+    assert body["token_type"] == "Bearer" and body["access_token"] and body["refresh_token"]
+
+
+def test_inject_429_with_retry_after_then_resumes(mock_base):
+    requests.post(f"{mock_base}/_control/config", json={"fail_next_n": 1, "fail_status": 429, "retry_after": 7})
+    r1 = requests.get(f"{mock_base}/v1/tracks/trk000000")
+    assert r1.status_code == 429 and r1.headers.get("Retry-After") == "7"
+    assert requests.get(f"{mock_base}/v1/tracks/trk000000").status_code == 200  # resumed
+
+
+def test_inject_401(mock_base):
+    requests.post(f"{mock_base}/_control/config", json={"fail_next_n": 1, "fail_status": 401})
+    assert requests.get(f"{mock_base}/v1/tracks/trk000000").status_code == 401
+
+
+def test_inject_500_for_a_specific_url_only(mock_base):
+    requests.post(f"{mock_base}/_control/config", json={"fail_url_substring": "trk000005", "fail_status": 500})
+    assert requests.get(f"{mock_base}/v1/tracks/trk000005").status_code == 500
+    assert requests.get(f"{mock_base}/v1/tracks/trk000000").status_code == 200  # others unaffected


### PR DESCRIPTION
A controllable **local mock of the Spotify Web API** (Falcon — no new deps), as a profile-gated `spotify_mock` compose service.

- **mock_spotify/**: deterministic self-consistent catalog (self-referential hrefs, env-tunable size) + endpoints (paginated `/v1/me/tracks`, single + batch tracks/albums/artists, `/api/token`, `/authorize`) + a `/_control` **failure-injection** plane (429+Retry-After / 401 / 500).
- **Full offline crawl** via `docker-compose.mock.yml` (point the pipeline at the mock, no OAuth/rate-limits).
- **Tests**: 9 mock self-tests (incl. all three injections) + 2 E2E data-path tests (mock → real handler + Cypher → Neo4j). **46 tests pass.**
- **spin-up skill** updated with the mock workflow.

Phase 0 (configurable base URLs, #11) is the prereq. AWS deploy (Phase 3) is documented but not built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)