### PR TITLE
fix(api): bound 429 retries (no more infinite rate-limit loop)

### DIFF
--- a/application/api_call_engine.py
+++ b/application/api_call_engine.py
@@ -33,6 +33,10 @@ MAX_HTTP_500_ERROR_RETRIES_PER_REQUEST = 5
 # a punitive multi-hour Retry-After; we must not freeze this single synchronous
 # consumer that long. (Intent of d97e8ac was "sleep at most ten minutes".)
 MAX_RETRY_AFTER_SECONDS = 600
+# Cap on 429 retries for one request. The sleep is bounded, but a persistent ban
+# would otherwise loop forever (~10 min/iteration), pinning the worker. Give up
+# (and roll back the dedup mark) after this many so the worker can move on.
+MAX_HTTP_429_RETRIES_PER_REQUEST = 5
 
 SPOTIFY_API_TOKEN = None
 
@@ -61,6 +65,7 @@ def make_spotify_api_call(ch, method, properties, body):
     request_url = msg["request_url"]
     depth_of_search = msg["depth_of_search"]
     http_500_error_count = 0
+    http_429_error_count = 0
 
     while True:
         logger.info(f'GET: {request_url} ...')
@@ -95,6 +100,14 @@ def make_spotify_api_call(ch, method, properties, body):
                     continue
 
             elif r.status_code == 429:
+                http_429_error_count += 1
+                if http_429_error_count >= MAX_HTTP_429_RETRIES_PER_REQUEST:
+                    if CRAWLED_URL_DEDUP:
+                        unmark_url(request_url, depth_of_search)
+                    raise requests.exceptions.HTTPError(
+                        f'HTTP 429 rate limiting for {request_url} exceeded max retry count '
+                        f'of {MAX_HTTP_429_RETRIES_PER_REQUEST}'
+                    )
                 # Retry-After is usually delta-seconds but may be an HTTP-date;
                 # fall back to 60s rather than letting int() raise.
                 try:
@@ -103,8 +116,8 @@ def make_spotify_api_call(ch, method, properties, body):
                     retry_after = 60
                 seconds_to_wait = min(retry_after, MAX_RETRY_AFTER_SECONDS)
                 logger.warning(
-                    f'HTTP 429: Rate limit exceeded (Retry-After={retry_after}s). '
-                    f'Waiting {seconds_to_wait}s to retry...'
+                    f'HTTP 429 #{http_429_error_count}: Rate limit exceeded '
+                    f'(Retry-After={retry_after}s). Waiting {seconds_to_wait}s to retry...'
                 )
                 sleep(seconds_to_wait)
                 continue

--- a/tests/test_engine_resilience.py
+++ b/tests/test_engine_resilience.py
@@ -61,3 +61,18 @@ def test_500_exhaustion_gives_up_and_rolls_back_dedup(engine_env, mock_base, red
     with pytest.raises(requests.exceptions.HTTPError):
         _call(url)                                  # 5x 500 -> give up + unmark + raise
     assert url_is_new(url, 0) is True              # True again => it was rolled back
+
+
+def test_persistent_429_gives_up_instead_of_looping_forever(engine_env, mock_base, redis_client):
+    # A persistent ban must not loop forever: bounded retries -> give up, and
+    # (like 500 exhaustion) the URL is rolled back so it stays re-requestable.
+    from application.cache.redis_client import url_is_new, reset_crawled_set
+    reset_crawled_set()
+    url = f"{mock_base}/v1/tracks/trk000006"
+    requests.post(f"{mock_base}/_control/config",
+                  json={"fail_url_substring": "trk000006", "fail_status": 429, "retry_after": 0})
+
+    assert url_is_new(url, 0) is True
+    with pytest.raises(requests.exceptions.HTTPError):
+        _call(url)                                  # always 429 -> bounded retries -> give up
+    assert url_is_new(url, 0) is True              # rolled back


### PR DESCRIPTION
Resilience limitation #1 from the engine-test review. The 429 sleep was capped but retries were unbounded, so a persistent ban (real Spotify ~24h Retry-After) would pin the worker forever. Now caps at 5 retries, then gives up + rolls back the dedup mark (same as the 500 path). New test: persistent 429 -> give up -> URL re-requestable. **50 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)