### PR TITLE
Bugfixes uncovered during the live crawl run

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,7 +89,7 @@ requests_factory ──► Requests exchange ──► api_call_engine ──►
 - [x] **Cap the 429 backoff** at 10 min (`max`→`min`) so a punitive `Retry-After` can't freeze the worker.
 - [x] **Redis crawled-URL dedup** — durable Redis service (AOF + named volume); one persistent `spb:crawled_urls` set; `SADD`-skip at the `request_url` choke point (`CRAWLED_URL_DEDUP`, default on); `RESET_CRAWL` for a fresh crawl. The fix for the request flood.
 - [x] **Batch endpoints behind a feature flag** (`USE_BATCH_ENDPOINTS`, **default off**) — `request_batch` (chunked `?ids=`, caps 50/20/50) + "Get Several" handlers + `UNWIND` Cypher + dispatcher routing + `follow_links` branch. A 20-song page → 3 calls instead of ~67 (~22× fewer at 12k scale).
-- [ ] **Live-verify batch access** post rate-limit cooldown (~2026-06-22) via `_probe_batch_endpoints.py`; if 200, set `USE_BATCH_ENDPOINTS=true` via env. _Existing apps currently retain batch endpoints, but Spotify only **postponed** removing them — keep the per-item fallback._
+- [x] **Live-verify batch access** — verified **2026-07-06** post-cooldown: the `?ids=` batch endpoints for tracks/albums/artists all return `200` for this app, so live crawls now run with `USE_BATCH_ENDPOINTS=true`. _Spotify only **postponed** removing them, so the per-item fallback (flag off) stays._
 - [ ] _(later)_ Cross-response Neo4j batching (buffer N / flush on interval) — secondary; the API-call batching above is the bigger win.
 - [ ] _(later)_ Remove the dead `check_url_match()` stubs.
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -91,6 +91,14 @@ services:
       - rabbitmq
       - redis
     command: bash -c "sleep 5 && python3 application/api_call_engine.py"
+    # Crawl-efficiency flags, overridable at `docker compose up` time, e.g.
+    #   RESET_CRAWL=true USE_BATCH_ENDPOINTS=true docker compose up
+    # Defaults mirror application/config.py so an unset shell var keeps the
+    # documented default (notably CRAWLED_URL_DEDUP stays ON).
+    environment:
+      RESET_CRAWL: ${RESET_CRAWL:-false}
+      USE_BATCH_ENDPOINTS: ${USE_BATCH_ENDPOINTS:-false}
+      CRAWLED_URL_DEDUP: ${CRAWLED_URL_DEDUP:-true}
 
   responses_write_to_disk:
     image: "spotify-power-browser:latest"
@@ -104,12 +112,19 @@ services:
     links:
       - rabbitmq
     command: python3 application/response_handlers/main.py write_to_disk
+    environment:
+      RESET_CRAWL: ${RESET_CRAWL:-false}
+      USE_BATCH_ENDPOINTS: ${USE_BATCH_ENDPOINTS:-false}
+      CRAWLED_URL_DEDUP: ${CRAWLED_URL_DEDUP:-true}
 
   responses_write_to_neo4j:
     image: "spotify-power-browser:latest"
     # Point this worker at Neo4j Desktop on the host rather than a container.
     environment:
       NEO4J_HOSTNAME: host.docker.internal
+      RESET_CRAWL: ${RESET_CRAWL:-false}
+      USE_BATCH_ENDPOINTS: ${USE_BATCH_ENDPOINTS:-false}
+      CRAWLED_URL_DEDUP: ${CRAWLED_URL_DEDUP:-true}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
@@ -139,6 +154,10 @@ services:
       - rabbitmq
       - redis
     command: python3 application/response_handlers/main.py follow_links
+    environment:
+      RESET_CRAWL: ${RESET_CRAWL:-false}
+      USE_BATCH_ENDPOINTS: ${USE_BATCH_ENDPOINTS:-false}
+      CRAWLED_URL_DEDUP: ${CRAWLED_URL_DEDUP:-true}
 
   requests_factory_start_crawls:
     image: "spotify-power-browser:latest"
@@ -167,6 +186,10 @@ services:
       - rabbitmq
       - redis
     command: bash -c "sleep 5 && python3 application/requests_factory.py"
+    environment:
+      RESET_CRAWL: ${RESET_CRAWL:-false}
+      USE_BATCH_ENDPOINTS: ${USE_BATCH_ENDPOINTS:-false}
+      CRAWLED_URL_DEDUP: ${CRAWLED_URL_DEDUP:-true}
 
   spotify_mock:
     image: "spotify-power-browser:latest"


### PR DESCRIPTION
Accumulating branch for fixes surfaced while restarting the live Liked-Songs crawl on **2026-07-06** (post rate-limit cooldown).

> **Draft** — collecting fixes as the crawl runs; merge once it completes.

## Fixes so far

- **fix(compose): pass crawl-efficiency flags through to containers** — `RESET_CRAWL` / `USE_BATCH_ENDPOINTS` / `CRAWLED_URL_DEDUP` are read from `os.environ` in the containers, but no service declared an `environment:` passthrough. So the documented `RESET_CRAWL=true docker compose up` (and the batch flag) only fed compose interpolation and **never reached the container** — a "fresh crawl" silently wouldn't reset the Redis dedup set, and batching couldn't be enabled. Verified empirically: `RESET_CRAWL=[]` before the fix, `[true]` after. Defaults mirror `application/config.py`, so an unset var keeps the documented default (dedup stays **on**). Also fixes the same latent no-op behind the mock override's documented `RESET_CRAWL=true` usage.
- **docs(roadmap): mark batch-endpoint access live-verified (2026-07-06)** — the `?ids=` batch endpoints returned `200` for tracks/albums/artists for this app, so the live crawl now runs with `USE_BATCH_ENDPOINTS=true` (~22× fewer API calls at 12k scale). Spotify only *postponed* removing them, so the per-item fallback stays.

## Known follow-up (not in this branch)

- Cosmetic: the `spin-up` skill's Neo4j count snippet uses `RETURN count(n) c` (missing `AS`), which errors on Neo4j 6. The edit was permission-blocked (`.claude/skills/` is gated), so it needs a manual touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
