### PR TITLE
fix(auth): client authentication on token refresh (the ~1h crawl wall)

### DIFF
--- a/application/spotify_authentication/refresh_token.py
+++ b/application/spotify_authentication/refresh_token.py
@@ -3,6 +3,7 @@ import requests
 from application.config import SECRETS_DIR, SPOTIFY_ACCOUNTS_BASE_URL
 
 SPOTIFY_CLIENT_ID_FILE = SECRETS_DIR / "spotify_client_id.secret"
+SPOTIFY_CLIENT_SECRET_FILE = SECRETS_DIR / "spotify_client_secret.secret"
 SPOTIFY_API_TOKEN_FILE = SECRETS_DIR / "spotify_api_token.secret"
 SPOTIFY_REFRESH_TOKEN_FILE = SECRETS_DIR / "spotify_refresh_token.secret"
 
@@ -12,11 +13,23 @@ def refresh_spotify_auth():
     with open(SPOTIFY_REFRESH_TOKEN_FILE, "r") as f:
         refresh_token = f.read()
 
+    with open(SPOTIFY_CLIENT_ID_FILE, "r") as f:
+        client_id = f.read()
+
+    with open(SPOTIFY_CLIENT_SECRET_FILE, "r") as f:
+        client_secret = f.read()
+
+    # Spotify's token endpoint requires client authentication on the refresh
+    # grant — the same HTTP Basic scheme the initial authorization-code
+    # exchange uses (api_authorization_web_service.py). Without it the request
+    # is rejected with HTTP 400, which used to kill every crawl at the ~1h
+    # access-token expiry wall.
     r = requests.post(f'{SPOTIFY_ACCOUNTS_BASE_URL}/api/token',
                       data={
                           "grant_type": 'refresh_token',
                           "refresh_token": refresh_token
                       },
+                      auth=(client_id, client_secret),
                       headers={
                           "Content-Type": "application/x-www-form-urlencoded"
                       })
@@ -25,15 +38,12 @@ def refresh_spotify_auth():
     r = r.json()
 
     access_token = r["access_token"]
-    token_type = r["token_type"]
-    scope = r["scope"]
-    expires_in = r["expires_in"]
-    refresh_token = r["refresh_token"]
+    # Spotify commonly omits refresh_token in refresh responses; keep using
+    # the current one then (per RFC 6749 §6 the old token stays valid).
+    refresh_token = r.get("refresh_token", refresh_token)
 
     with open(SPOTIFY_API_TOKEN_FILE, "w") as f:
         f.write(access_token)
 
     with open(SPOTIFY_REFRESH_TOKEN_FILE, "w") as f:
         f.write(refresh_token)
-
-

--- a/mock_spotify/app.py
+++ b/mock_spotify/app.py
@@ -83,13 +83,28 @@ class BatchResource:
 
 class TokenResource:
     def on_post(self, req, resp):
+        # Fidelity: Spotify's token endpoint rejects clients that don't
+        # authenticate (HTTP Basic). The permissive version of this mock let a
+        # missing-client-auth bug in refresh_spotify_auth() ship undetected.
+        if not (req.auth or "").startswith("Basic "):
+            resp.status = falcon.HTTP_400
+            resp.media = {
+                "error": "invalid_client",
+                "error_description": "client authentication required",
+            }
+            return
+
+        form = req.get_media() if req.content_length else {}
         resp.media = {
             "access_token": "mock-access-token",
             "token_type": "Bearer",
             "scope": "user-library-read",
             "expires_in": 3600,
-            "refresh_token": "mock-refresh-token",
         }
+        # Spotify includes a refresh_token on the initial code exchange but
+        # commonly omits it when the grant is itself a refresh.
+        if form.get("grant_type") != "refresh_token":
+            resp.media["refresh_token"] = "mock-refresh-token"
 
 
 class AuthorizeResource:

--- a/tests/test_mock_service.py
+++ b/tests/test_mock_service.py
@@ -36,8 +36,20 @@ def test_batch_returns_objects_and_nulls_for_unknown(mock_base):
 
 
 def test_token_endpoint(mock_base):
-    body = requests.post(f"{mock_base}/api/token", data={"grant_type": "refresh_token"}).json()
+    # Authenticated code exchange includes a refresh_token...
+    body = requests.post(
+        f"{mock_base}/api/token",
+        data={"grant_type": "authorization_code", "code": "mock-auth-code"},
+        auth=("mock-client-id", "mock-client-secret"),
+    ).json()
     assert body["token_type"] == "Bearer" and body["access_token"] and body["refresh_token"]
+    # ...while a refresh grant omits it (as Spotify commonly does).
+    body = requests.post(
+        f"{mock_base}/api/token",
+        data={"grant_type": "refresh_token", "refresh_token": "mock-refresh-token"},
+        auth=("mock-client-id", "mock-client-secret"),
+    ).json()
+    assert body["access_token"] and "refresh_token" not in body
 
 
 def test_inject_429_with_retry_after_then_resumes(mock_base):

--- a/tests/test_refresh_token.py
+++ b/tests/test_refresh_token.py
@@ -1,0 +1,44 @@
+"""refresh_spotify_auth() against the mock token endpoint.
+
+The live-run bug this guards: the refresh POST went out with no client
+authentication and Spotify 400'd it, so every crawl died at the ~1h access
+token expiry. The mock now rejects unauthenticated token requests (like
+Spotify) and omits refresh_token from refresh responses (like Spotify often
+does), so both regressions are pinned here end-to-end.
+"""
+import requests
+
+import application.spotify_authentication.refresh_token as rt
+
+
+def _wire_secrets(monkeypatch, tmp_path, mock_base):
+    (tmp_path / "spotify_client_id.secret").write_text("mock-client-id")
+    (tmp_path / "spotify_client_secret.secret").write_text("mock-client-secret")
+    (tmp_path / "spotify_api_token.secret").write_text("expired-token")
+    (tmp_path / "spotify_refresh_token.secret").write_text("mock-refresh-token")
+    monkeypatch.setattr(rt, "SPOTIFY_CLIENT_ID_FILE", tmp_path / "spotify_client_id.secret")
+    monkeypatch.setattr(rt, "SPOTIFY_CLIENT_SECRET_FILE", tmp_path / "spotify_client_secret.secret")
+    monkeypatch.setattr(rt, "SPOTIFY_API_TOKEN_FILE", tmp_path / "spotify_api_token.secret")
+    monkeypatch.setattr(rt, "SPOTIFY_REFRESH_TOKEN_FILE", tmp_path / "spotify_refresh_token.secret")
+    monkeypatch.setattr(rt, "SPOTIFY_ACCOUNTS_BASE_URL", mock_base)
+
+
+def test_refresh_authenticates_and_rewrites_access_token(monkeypatch, tmp_path, mock_base):
+    _wire_secrets(monkeypatch, tmp_path, mock_base)
+
+    rt.refresh_spotify_auth()
+
+    assert (tmp_path / "spotify_api_token.secret").read_text() == "mock-access-token"
+    # The mock (like Spotify) omits refresh_token on a refresh grant; the old
+    # one must be kept, not clobbered or KeyError'd.
+    assert (tmp_path / "spotify_refresh_token.secret").read_text() == "mock-refresh-token"
+
+
+def test_mock_token_endpoint_rejects_missing_client_auth(mock_base):
+    r = requests.post(
+        f"{mock_base}/api/token",
+        data={"grant_type": "refresh_token", "refresh_token": "mock-refresh-token"},
+        timeout=5,
+    )
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_client"


### PR DESCRIPTION
Found live on **2026-07-06**, minutes after the first successful full crawl: `refresh_spotify_auth()` sent the refresh grant with **no client authentication**, so Spotify's token endpoint rejected it with HTTP 400. Any crawl longer than the ~1h access-token lifetime would die at the expiry wall (the engine's 401 path raises, and with `auto_ack` the in-flight messages drain into the void). Today's 18-minute crawl simply never lived long enough to hit it.

- **fix(auth)**: use the same HTTP Basic client auth as the initial authorization-code exchange; tolerate Spotify omitting `refresh_token` in refresh responses (RFC 6749 §6) instead of `KeyError`'ing.
- **test(mock)**: the mock's token endpoint was permissive (accepted anything, always returned `refresh_token`) — exactly why this shipped undetected. It now 400s unauthenticated clients and omits `refresh_token` on refresh grants, with end-to-end tests pinning `refresh_spotify_auth()` against it.

**Verification**: 52 tests green (`docker compose run --rm tests`); live refresh against real Spotify mints a working token (`GET /v1/me` → 200) after the pre-fix code 400'd.

Unblocks every >1h crawl in the upcoming feature plans (depth-2 discovery, discography backfills, multiplayer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)