### PR TITLE
fix(graph_database): require WITH between MERGE and CALL for Neo4j 5.26

### DIFF
--- a/application/graph_database/queries/insert_batch_of_tracks.cypher
+++ b/application/graph_database/queries/insert_batch_of_tracks.cypher
@@ -28,6 +28,10 @@ ON CREATE SET
 
 MERGE (t)<-[:CONTAINS]-(al)
 
+// Neo4j requires a WITH between a MERGE and a following CALL subquery; 5.26-line
+// servers reject the bare form as a syntax error. Pass the merged nodes forward.
+WITH track, t, al
+
 // Link the artists credited on the track's album. Independent CALL subquery so
 // an empty album.artists list can't drop the track's row before its own
 // performing artists are linked below.

--- a/application/graph_database/queries/insert_single_track.cypher
+++ b/application/graph_database/queries/insert_single_track.cypher
@@ -27,6 +27,10 @@ ON CREATE SET
 
 MERGE (t)<-[:CONTAINS]-(al)
 
+// Neo4j requires a WITH between a MERGE and a following CALL subquery; 5.26-line
+// servers reject the bare form as a syntax error. Pass the merged nodes forward.
+WITH track, t, al
+
 // Link the artists credited on the track's album. Independent CALL subquery so
 // an empty album.artists list can't drop the track's row before its own
 // performing artists are linked below.


### PR DESCRIPTION
## Problem
`insert_batch_of_tracks.cypher` and `insert_single_track.cypher` place a scoped `CALL (…) {…}` subquery directly after a `MERGE`. Neo4j **5.26-line** servers (`neo4j:5` = 5.26.28) reject that at parse time:

> `Neo.ClientError.Statement.SyntaxError: WITH is required between MERGE and CALL`

The live crawl's host Neo4j Desktop is laxer and accepts the bare form, so the incompatibility stayed latent through a full crawl. It surfaced while validating Cypher against a throwaway `neo4j:5` container.

## Fix
Insert `WITH track, t, al` between the last `MERGE` and the first `CALL` in both files. Only the bare `MERGE`→`CALL` needs it; the second `CALL` (preceded by a `CALL` subquery) does not. The `WITH` is a pass-through projection — backward-compatible with servers that already accept the current form.

## Verification (throwaway `neo4j:5` = 5.26.28, isolated network, live crawl untouched)
| Check | Unfixed | Fixed |
|---|---|---|
| `EXPLAIN` batch query | ❌ error @ line 34 | ✅ plans |
| `EXPLAIN` single query | ❌ error @ line 33 | ✅ plans |
| `pytest tests/test_neo4j_cypher.py` (real handler path) | ❌ `CypherSyntaxError` | ✅ 2 passed |

The control run (original query overlaid) failing with the exact production error confirms the test genuinely catches this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)