### PR TITLE
Plan 03: Entity mastering — canonical Songs across re-releases

### DIFF
--- a/application/graph_database/queries/apply_uniqueness_constraints_to_nodes.cypher
+++ b/application/graph_database/queries/apply_uniqueness_constraints_to_nodes.cypher
@@ -9,3 +9,8 @@ REQUIRE artist.id IS UNIQUE;
 CREATE CONSTRAINT track_id_uniqueness IF NOT EXISTS
 FOR (track:Track)
 REQUIRE track.id IS UNIQUE;
+
+// --- Entity mastering (plan 03): canonical Song masters ---
+CREATE CONSTRAINT song_id_uniqueness IF NOT EXISTS
+FOR (song:Song)
+REQUIRE song.id IS UNIQUE;

--- a/application/graph_database/queries/insert_batch_of_liked_songs.cypher
+++ b/application/graph_database/queries/insert_batch_of_liked_songs.cypher
@@ -15,6 +15,10 @@ ON CREATE SET
     t.isrc = track.external_ids.isrc,
     t.album_type = track.album.album_type,
     t.linked_from_id = track.linked_from.id,
+    // The track's OWN performing artists, in credit order (CREATED edges also
+    // include album artists and lose order, so mastering needs this list to
+    // know the primary artist).
+    t.artist_ids = [artist IN track.artists | artist.id],
     t.liked_songs = true,
     t.date_added_to_liked_songs = track.added_at
 ON MATCH SET
@@ -25,7 +29,8 @@ ON MATCH SET
     // can't erase a previously stored value.
     t.isrc = coalesce(track.external_ids.isrc, t.isrc),
     t.album_type = coalesce(track.album.album_type, t.album_type),
-    t.linked_from_id = coalesce(track.linked_from.id, t.linked_from_id)
+    t.linked_from_id = coalesce(track.linked_from.id, t.linked_from_id),
+    t.artist_ids = coalesce([artist IN track.artists | artist.id], t.artist_ids)
 
 MERGE (al:Album {uri: track.album.uri})
 ON CREATE SET

--- a/application/graph_database/queries/insert_batch_of_liked_songs.cypher
+++ b/application/graph_database/queries/insert_batch_of_liked_songs.cypher
@@ -12,11 +12,20 @@ ON CREATE SET
     t.type = track.type,
     t.href = track.href,
     t.spotify_url = track.external_urls.spotify,
+    t.isrc = track.external_ids.isrc,
+    t.album_type = track.album.album_type,
+    t.linked_from_id = track.linked_from.id,
     t.liked_songs = true,
     t.date_added_to_liked_songs = track.added_at
 ON MATCH SET
     t.liked_songs = true,
-    t.date_added_to_liked_songs = track.added_at
+    t.date_added_to_liked_songs = track.added_at,
+    // Entity mastering (plan 03): refresh the enrichment fields on re-insert so
+    // backfills update existing nodes; coalesce so a payload that lacks a field
+    // can't erase a previously stored value.
+    t.isrc = coalesce(track.external_ids.isrc, t.isrc),
+    t.album_type = coalesce(track.album.album_type, t.album_type),
+    t.linked_from_id = coalesce(track.linked_from.id, t.linked_from_id)
 
 MERGE (al:Album {uri: track.album.uri})
 ON CREATE SET

--- a/application/graph_database/queries/insert_batch_of_tracks.cypher
+++ b/application/graph_database/queries/insert_batch_of_tracks.cypher
@@ -14,14 +14,19 @@ ON CREATE SET
     t.spotify_url = track.external_urls.spotify,
     t.isrc = track.external_ids.isrc,
     t.album_type = track.album.album_type,
-    t.linked_from_id = track.linked_from.id
+    t.linked_from_id = track.linked_from.id,
+    // The track's OWN performing artists, in credit order (CREATED edges also
+    // include album artists and lose order, so mastering needs this list to
+    // know the primary artist).
+    t.artist_ids = [artist IN track.artists | artist.id]
 // Entity mastering (plan 03): refresh the enrichment fields on re-insert so
 // backfills update existing nodes; coalesce so a payload that lacks a field
 // can't erase a previously stored value.
 ON MATCH SET
     t.isrc = coalesce(track.external_ids.isrc, t.isrc),
     t.album_type = coalesce(track.album.album_type, t.album_type),
-    t.linked_from_id = coalesce(track.linked_from.id, t.linked_from_id)
+    t.linked_from_id = coalesce(track.linked_from.id, t.linked_from_id),
+    t.artist_ids = coalesce([artist IN track.artists | artist.id], t.artist_ids)
 
 MERGE (al:Album {uri: track.album.uri})
 ON CREATE SET

--- a/application/graph_database/queries/insert_batch_of_tracks.cypher
+++ b/application/graph_database/queries/insert_batch_of_tracks.cypher
@@ -11,7 +11,17 @@ ON CREATE SET
     t.duration_ms = track.duration_ms,
     t.type = track.type,
     t.href = track.href,
-    t.spotify_url = track.external_urls.spotify
+    t.spotify_url = track.external_urls.spotify,
+    t.isrc = track.external_ids.isrc,
+    t.album_type = track.album.album_type,
+    t.linked_from_id = track.linked_from.id
+// Entity mastering (plan 03): refresh the enrichment fields on re-insert so
+// backfills update existing nodes; coalesce so a payload that lacks a field
+// can't erase a previously stored value.
+ON MATCH SET
+    t.isrc = coalesce(track.external_ids.isrc, t.isrc),
+    t.album_type = coalesce(track.album.album_type, t.album_type),
+    t.linked_from_id = coalesce(track.linked_from.id, t.linked_from_id)
 
 MERGE (al:Album {uri: track.album.uri})
 ON CREATE SET

--- a/application/graph_database/queries/insert_single_track.cypher
+++ b/application/graph_database/queries/insert_single_track.cypher
@@ -13,14 +13,19 @@ ON CREATE SET
     t.spotify_url = track.external_urls.spotify,
     t.isrc = track.external_ids.isrc,
     t.album_type = track.album.album_type,
-    t.linked_from_id = track.linked_from.id
+    t.linked_from_id = track.linked_from.id,
+    // The track's OWN performing artists, in credit order (CREATED edges also
+    // include album artists and lose order, so mastering needs this list to
+    // know the primary artist).
+    t.artist_ids = [artist IN track.artists | artist.id]
 // Entity mastering (plan 03): refresh the enrichment fields on re-insert so
 // backfills update existing nodes; coalesce so a payload that lacks a field
 // can't erase a previously stored value.
 ON MATCH SET
     t.isrc = coalesce(track.external_ids.isrc, t.isrc),
     t.album_type = coalesce(track.album.album_type, t.album_type),
-    t.linked_from_id = coalesce(track.linked_from.id, t.linked_from_id)
+    t.linked_from_id = coalesce(track.linked_from.id, t.linked_from_id),
+    t.artist_ids = coalesce([artist IN track.artists | artist.id], t.artist_ids)
 
 MERGE (al:Album {uri: track.album.uri})
 ON CREATE SET

--- a/application/graph_database/queries/insert_single_track.cypher
+++ b/application/graph_database/queries/insert_single_track.cypher
@@ -10,7 +10,17 @@ ON CREATE SET
     t.duration_ms = track.duration_ms,
     t.type = track.type,
     t.href = track.href,
-    t.spotify_url = track.external_urls.spotify
+    t.spotify_url = track.external_urls.spotify,
+    t.isrc = track.external_ids.isrc,
+    t.album_type = track.album.album_type,
+    t.linked_from_id = track.linked_from.id
+// Entity mastering (plan 03): refresh the enrichment fields on re-insert so
+// backfills update existing nodes; coalesce so a payload that lacks a field
+// can't erase a previously stored value.
+ON MATCH SET
+    t.isrc = coalesce(track.external_ids.isrc, t.isrc),
+    t.album_type = coalesce(track.album.album_type, t.album_type),
+    t.linked_from_id = coalesce(track.linked_from.id, t.linked_from_id)
 
 MERGE (al:Album {uri: track.album.uri})
 ON CREATE SET

--- a/application/graph_database/queries/mastering/fetch_track_ids_missing_isrc.cypher
+++ b/application/graph_database/queries/mastering/fetch_track_ids_missing_isrc.cypher
@@ -1,0 +1,11 @@
+// Entity mastering (plan 03): the backfill worklist — every non-local Track
+// that has not yet been enriched with its ISRC. (Local files have no Spotify
+// catalog entry to refetch, so they are excluded — the plan's "0 tracks
+// without isrc (minus is_local)" done-condition.)
+MATCH (t:Track)
+WHERE t.isrc IS NULL
+  AND coalesce(t.is_local, false) = false
+  AND t.id IS NOT NULL
+RETURN t.id AS id
+ORDER BY id
+;

--- a/application/graph_database/queries/mastering/fetch_tracks_for_mastering.cypher
+++ b/application/graph_database/queries/mastering/fetch_tracks_for_mastering.cypher
@@ -1,0 +1,19 @@
+// Entity mastering (plan 03): pull every non-local Track with the fields the
+// clustering job needs. CREATED edges are unordered, so artist ids/names come
+// back sorted and run.py treats the lexicographically smallest id as a stable
+// primary-artist proxy for the heuristic blocking key.
+MATCH (t:Track)
+WHERE coalesce(t.is_local, false) = false
+OPTIONAL MATCH (t)<-[:CREATED]-(ar:Artist)
+WITH t, ar ORDER BY ar.id
+WITH t, collect(ar.id) AS artist_ids, collect(ar.name) AS artist_names
+RETURN
+    t.id AS id,
+    t.name AS name,
+    t.isrc AS isrc,
+    t.linked_from_id AS linked_from_id,
+    t.duration_ms AS duration_ms,
+    t.explicit AS explicit,
+    artist_ids,
+    artist_names
+;

--- a/application/graph_database/queries/mastering/fetch_tracks_for_mastering.cypher
+++ b/application/graph_database/queries/mastering/fetch_tracks_for_mastering.cypher
@@ -1,12 +1,20 @@
 // Entity mastering (plan 03): pull every non-local Track with the fields the
-// clustering job needs. CREATED edges are unordered, so artist ids/names come
-// back sorted and run.py treats the lexicographically smallest id as a stable
-// primary-artist proxy for the heuristic blocking key.
+// clustering job needs.
+//
+// artist_ids: prefer t.artist_ids — the track's OWN performing artists in
+// credit order, persisted by the insert Cyphers (first = primary artist).
+// Legacy nodes crawled before that field existed fall back to the CREATED
+// edges, which are unordered AND include album artists — a weaker proxy
+// (smallest id as pseudo-primary). The ISRC backfill refreshes t.artist_ids
+// on every node it touches, so the fallback disappears after one backfill.
+//
+// artist_names: collected from CREATED edges; only used as a set to decide
+// whether a "feat. X" clause is redundant, so order doesn't matter.
 MATCH (t:Track)
 WHERE coalesce(t.is_local, false) = false
 OPTIONAL MATCH (t)<-[:CREATED]-(ar:Artist)
 WITH t, ar ORDER BY ar.id
-WITH t, collect(ar.id) AS artist_ids, collect(ar.name) AS artist_names
+WITH t, collect(ar.id) AS edge_artist_ids, collect(ar.name) AS artist_names
 RETURN
     t.id AS id,
     t.name AS name,
@@ -14,6 +22,6 @@ RETURN
     t.linked_from_id AS linked_from_id,
     t.duration_ms AS duration_ms,
     t.explicit AS explicit,
-    artist_ids,
+    coalesce(t.artist_ids, edge_artist_ids) AS artist_ids,
     artist_names
 ;

--- a/application/graph_database/queries/mastering/merge_remix_of.cypher
+++ b/application/graph_database/queries/mastering/merge_remix_of.cypher
@@ -1,0 +1,11 @@
+// Entity mastering (plan 03): a remix rolls up to its OWN Song, with a
+// REMIX_OF edge to the parent Song when the parent was resolvable by
+// (primary artist, base title with the remix credit removed).
+UNWIND $edges AS edge
+
+MATCH (remix:Song {id: edge.remix_song_id})
+MATCH (parent:Song {id: edge.parent_song_id})
+
+MERGE (remix)-[r:REMIX_OF]->(parent)
+SET r.confidence = edge.confidence
+;

--- a/application/graph_database/queries/mastering/merge_remix_of.cypher
+++ b/application/graph_database/queries/mastering/merge_remix_of.cypher
@@ -1,10 +1,20 @@
 // Entity mastering (plan 03): a remix rolls up to its OWN Song, with a
 // REMIX_OF edge to the parent Song when the parent was resolvable by
 // (primary artist, base title with the remix credit removed).
+// Idempotent and re-runnable, mirroring VERSION_OF in
+// merge_song_clusters.cypher: when the parent cluster's id changes between
+// runs (e.g. a new variant flips it from a bare ISRC to a song:<hash>), the
+// remix is RE-POINTED — the stale edge is deleted; the orphaned parent Song
+// node itself is never deleted.
 UNWIND $edges AS edge
 
 MATCH (remix:Song {id: edge.remix_song_id})
 MATCH (parent:Song {id: edge.parent_song_id})
+
+// A remix points at exactly one parent: drop any edge to a different Song.
+OPTIONAL MATCH (remix)-[stale:REMIX_OF]->(other:Song)
+WHERE other.id <> edge.parent_song_id
+DELETE stale
 
 MERGE (remix)-[r:REMIX_OF]->(parent)
 SET r.confidence = edge.confidence

--- a/application/graph_database/queries/mastering/merge_song_clusters.cypher
+++ b/application/graph_database/queries/mastering/merge_song_clusters.cypher
@@ -1,0 +1,26 @@
+// Entity mastering (plan 03): MERGE canonical (:Song) nodes and point each
+// member (:Track) at its Song with exactly ONE VERSION_OF edge. Idempotent and
+// re-runnable: a track whose cluster changed is RE-POINTED (the stale edge is
+// deleted), but Songs are never deleted — an orphaned Song is harmless and a
+// later run may repopulate it.
+UNWIND $clusters AS cluster
+
+MERGE (s:Song {id: cluster.song_id})
+SET s.title = cluster.title
+
+WITH cluster, s
+UNWIND cluster.members AS member
+
+MATCH (t:Track {id: member.track_id})
+
+// A Track has exactly one VERSION_OF: drop any edge to a different Song.
+OPTIONAL MATCH (t)-[stale:VERSION_OF]->(other:Song)
+WHERE other.id <> cluster.song_id
+DELETE stale
+
+MERGE (t)-[v:VERSION_OF]->(s)
+SET
+    v.kind = member.kind,
+    v.method = member.method,
+    v.confidence = member.confidence
+;

--- a/application/graph_database/queries/mastering/song_altitude_queries.cypher
+++ b/application/graph_database/queries/mastering/song_altitude_queries.cypher
@@ -1,0 +1,100 @@
+// Entity mastering (plan 03 T8): the plan-01 (discovery) and plan-02
+// (completeness) deliverable queries, documented at BOTH altitudes.
+//
+// Track altitude = release-level truth: every distinct Spotify track id
+// counts. Song altitude = listener-level truth: aggregate through
+// (:Track)-[:VERSION_OF]->(:Song) so re-releases collapse. Every Track has
+// exactly one VERSION_OF after `python -m application.mastering.run`, so the
+// two altitudes cover the same tracks — pick per question.
+//
+// This file is a documented query pack (not executed by the pipeline).
+// Queries are separated by semicolons and take $-parameters. Keep literal
+// semicolons out of the comments — tooling splits on them.
+
+
+// ---------------------------------------------------------------------------
+// 1a. Adjacent-artist discovery (plan 01 deliverable) — TRACK altitude.
+// A collab re-released on five editions counts five times: inflated.
+// Params: $max_popularity (e.g. 40), $min_bridges (e.g. 3)
+// ---------------------------------------------------------------------------
+MATCH (mine:Artist)-[:CREATED]->(:Track {liked_songs: true})
+WITH collect(DISTINCT mine) AS my_artists
+UNWIND my_artists AS m
+MATCH (m)-[:CREATED]->(t:Track)<-[:CREATED]-(cand:Artist)
+WHERE NOT cand IN my_artists AND cand.popularity <= $max_popularity
+WITH cand, count(DISTINCT m) AS bridges,
+     collect(DISTINCT m.name)[..5] AS via
+WHERE bridges >= $min_bridges
+RETURN cand.name AS artist, cand.popularity AS popularity, cand.followers AS followers,
+       bridges, via
+ORDER BY bridges DESC, cand.popularity ASC LIMIT 50
+;
+
+// ---------------------------------------------------------------------------
+// 1b. Adjacent-artist discovery — SONG altitude (the plan-03 improvement).
+// Collabs are counted as DISTINCT Songs, so a single collab spread across a
+// single, an album cut, and a deluxe re-release is one shared song, not
+// three. shared_songs ranks candidates by real overlap depth.
+// Params: $max_popularity, $min_bridges
+// ---------------------------------------------------------------------------
+MATCH (mine:Artist)-[:CREATED]->(:Track {liked_songs: true})
+WITH collect(DISTINCT mine) AS my_artists
+UNWIND my_artists AS m
+MATCH (m)-[:CREATED]->(t:Track)<-[:CREATED]-(cand:Artist)
+MATCH (t)-[:VERSION_OF]->(s:Song)
+WHERE NOT cand IN my_artists AND cand.popularity <= $max_popularity
+WITH cand, count(DISTINCT m) AS bridges, count(DISTINCT s) AS shared_songs,
+     collect(DISTINCT m.name)[..5] AS via
+WHERE bridges >= $min_bridges
+RETURN cand.name AS artist, cand.popularity AS popularity, cand.followers AS followers,
+       bridges, shared_songs, via
+ORDER BY bridges DESC, shared_songs DESC, cand.popularity ASC LIMIT 50
+;
+
+// ---------------------------------------------------------------------------
+// 2a. Artist listening completeness (plan 02 deliverable) — TRACK altitude.
+// A deluxe album shows ~30% "unheard" when you have heard every song,
+// because each re-released track counts as its own unheard item.
+// NOTE: (:User) and [:LISTENED_TO {ms_total}] land with plan 02 — this query
+// pack is forward-written for that schema.
+// Params: $me (user id)
+// ---------------------------------------------------------------------------
+MATCH (a:Artist)-[:CREATED]->(t:Track)
+OPTIONAL MATCH (u:User {id: $me})-[l:LISTENED_TO]->(t)
+WHERE l.ms_total >= 30000
+WITH a, count(DISTINCT t) AS catalog, count(DISTINCT l) AS heard
+WHERE catalog >= 10
+RETURN a.name AS artist, heard, catalog,
+       toFloat(heard) / catalog AS completeness
+ORDER BY completeness ASC
+;
+
+// ---------------------------------------------------------------------------
+// 2b. Artist listening completeness — SONG altitude (the plan-03 improvement).
+// "Songs heard", not "releases heard": a Song counts as heard when ANY of its
+// versions has a meaningful (>=30s) listen.
+// Params: $me (user id)
+// ---------------------------------------------------------------------------
+MATCH (a:Artist)-[:CREATED]->(:Track)-[:VERSION_OF]->(s:Song)
+WITH DISTINCT a, s
+OPTIONAL MATCH (u:User {id: $me})-[l:LISTENED_TO]->(:Track)-[:VERSION_OF]->(s)
+WHERE l.ms_total >= 30000
+WITH a, s, count(l) > 0 AS heard
+WITH a, count(s) AS catalog, sum(CASE WHEN heard THEN 1 ELSE 0 END) AS heard
+WHERE catalog >= 10
+RETURN a.name AS artist, heard, catalog,
+       toFloat(heard) / catalog AS completeness
+ORDER BY completeness ASC
+;
+
+// ---------------------------------------------------------------------------
+// 3. Bonus: Bloom / exploration at Song altitude — the visible-hairball fix.
+// One row per Song with its version fan-out, most-duplicated first: a direct
+// view of what mastering rolled up (and a sanity check after each run).
+// ---------------------------------------------------------------------------
+MATCH (t:Track)-[v:VERSION_OF]->(s:Song)
+WITH s, count(t) AS versions, collect(DISTINCT v.kind) AS kinds
+WHERE versions > 1
+RETURN s.id AS song_id, s.title AS title, versions, kinds
+ORDER BY versions DESC, title
+;

--- a/application/mastering/__init__.py
+++ b/application/mastering/__init__.py
@@ -1,0 +1,11 @@
+"""Entity mastering (plan 03): fold re-released track variants into canonical
+(:Song) masters without ever destroying release-level (:Track) truth.
+
+Layout:
+    normalize.py  title normalization + variant-kind extraction (pure)
+    cluster.py    the identity ladder on plain dicts (pure, no Neo4j)
+    overrides.py  manual forced merge/split YAML loading
+    report.py     human review report (markdown, ambiguity-sorted)
+    run.py        the offline batch job: Neo4j read -> cluster -> Neo4j write
+    backfill.py   batch refetch of tracks missing an ISRC (live API)
+"""

--- a/application/mastering/backfill.py
+++ b/application/mastering/backfill.py
@@ -1,0 +1,143 @@
+"""ISRC enrichment backfill (plan 03 T3): batch-refetch every Track that has
+no `isrc` yet and refresh it in Neo4j.
+
+    python -m application.mastering.backfill
+
+Synchronous and offline (not part of the crawl pipeline): reads the worklist
+from Neo4j, GETs the verified-alive batch endpoint /v1/tracks?ids= in chunks
+of 50 (12.5k tracks ~ 250 calls, minutes), and pushes the full track objects
+back through the existing several-tracks insert Cypher, whose ON MATCH SET
+now refreshes isrc / album_type / linked_from_id. Bounded 429/500 retries
+mirror the crawl engine's policy so a punitive Retry-After can't hang the run.
+
+Live prerequisites: a Spotify token in secrets/spotify_api_token.secret and
+Neo4j reachable — which is why this script ships written-but-unrun and gets
+exercised for real as a post-merge step.
+"""
+from time import sleep
+
+import requests
+
+from application.api_call_engine import get_api_token
+from application.config import APPLICATION_DIR, SECRETS_DIR, SPOTIFY_API_BASE_URL
+from application.graph_database.connect import connect_to_neo4j
+from application.loggers import get_logger
+
+logger = get_logger(__name__)
+
+MASTERING_QUERIES_DIR = APPLICATION_DIR / "graph_database" / "queries" / "mastering"
+NEO4J_CREDENTIALS_FILE = SECRETS_DIR / "neo4j_credentials.yaml"
+
+BATCH_SIZE = 50            # /v1/tracks?ids= accepts at most 50 ids
+MAX_429_RETRIES = 5        # mirror api_call_engine's bounded rate-limit policy
+MAX_500_RETRIES = 5
+MAX_RETRY_AFTER_SECONDS = 600
+DEFAULT_RETRY_AFTER_SECONDS = 60
+
+
+def chunked(items, size=BATCH_SIZE):
+    """Split a list into consecutive chunks of at most `size`."""
+    return [items[i:i + size] for i in range(0, len(items), size)]
+
+
+def fetch_track_ids_missing_isrc(driver, database="neo4j"):
+    with open(MASTERING_QUERIES_DIR / "fetch_track_ids_missing_isrc.cypher", "r") as f:
+        query = f.read()
+    records, _, _ = driver.execute_query(query, database_=database)
+    return [record["id"] for record in records]
+
+
+def _retry_after_seconds(response):
+    try:
+        retry_after = int(response.headers.get("Retry-After"))
+    except (TypeError, ValueError):
+        retry_after = DEFAULT_RETRY_AFTER_SECONDS
+    return min(retry_after, MAX_RETRY_AFTER_SECONDS)
+
+
+def fetch_tracks_batch(ids, http_get=requests.get, token=None, wait=sleep):
+    """GET one /v1/tracks?ids= batch with bounded 429/500 retries.
+
+    http_get / token / wait are injectable for offline tests. Returns the
+    resolved (non-null) full track objects.
+    """
+    url = f"{SPOTIFY_API_BASE_URL}/v1/tracks?ids={','.join(ids)}"
+    errors_429 = errors_500 = 0
+
+    while True:
+        response = http_get(
+            url, headers={"Authorization": f"Bearer {token or get_api_token()}"}
+        )
+
+        if response.status_code == 429:
+            errors_429 += 1
+            if errors_429 >= MAX_429_RETRIES:
+                raise requests.exceptions.HTTPError(
+                    f"HTTP 429 rate limiting for {url} exceeded max retry count of {MAX_429_RETRIES}"
+                )
+            seconds = _retry_after_seconds(response)
+            logger.warning(f"HTTP 429 #{errors_429} on backfill batch; waiting {seconds}s...")
+            wait(seconds)
+            continue
+
+        if response.status_code >= 500:
+            errors_500 += 1
+            if errors_500 >= MAX_500_RETRIES:
+                raise requests.exceptions.HTTPError(
+                    f"HTTP {response.status_code} for {url} exceeded max retry count of {MAX_500_RETRIES}"
+                )
+            logger.warning(f"HTTP {response.status_code} #{errors_500} on backfill batch; waiting 5s...")
+            wait(5)
+            continue
+
+        response.raise_for_status()
+        return [track for track in response.json()["tracks"] if track is not None]
+
+
+def backfill_missing_isrcs(driver, database="neo4j", http_get=requests.get,
+                           token=None, wait=sleep):
+    """The whole backfill against an existing driver. Returns run stats."""
+    # Import here: the handler module pulls in the request-factory stack,
+    # which this offline script only needs for its Cypher + write path.
+    from application.response_handlers.tracks.several_tracks import GetSeveralTracksResponseHandler
+
+    track_ids = fetch_track_ids_missing_isrc(driver, database=database)
+    batches = chunked(track_ids)
+    logger.info(f"Backfilling {len(track_ids)} tracks without isrc in {len(batches)} batches.")
+
+    refreshed = 0
+    for batch_number, ids in enumerate(batches, start=1):
+        tracks = fetch_tracks_batch(ids, http_get=http_get, token=token, wait=wait)
+        if tracks:
+            handler = GetSeveralTracksResponseHandler(
+                request_url=None, depth_of_search=0, response={"tracks": tracks}
+            )
+            handler.write_to_neo4j(driver=driver, database=database)
+        refreshed += len(tracks)
+        unresolved = len(ids) - len(tracks)
+        if unresolved:
+            logger.warning(f"Batch {batch_number}: {unresolved} id(s) did not resolve (deleted from catalog?).")
+        logger.info(f"Batch {batch_number}/{len(batches)}: refreshed {len(tracks)} tracks.")
+
+    remaining = fetch_track_ids_missing_isrc(driver, database=database)
+    if remaining:
+        # Some catalog entries genuinely lack an ISRC (very old/indie
+        # releases) — the heuristic tier and the review loop cover the tail.
+        logger.warning(f"{len(remaining)} tracks still have no isrc after the refetch.")
+    else:
+        logger.info("Backfill complete: 0 non-local tracks without isrc.")
+
+    return {"targeted": len(track_ids), "refreshed": refreshed, "still_missing": len(remaining)}
+
+
+def main():
+    driver = connect_to_neo4j(NEO4J_CREDENTIALS_FILE)
+    try:
+        stats = backfill_missing_isrcs(driver)
+        logger.info(f"Backfill stats: {stats}")
+    finally:
+        driver.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/application/mastering/cluster.py
+++ b/application/mastering/cluster.py
@@ -25,7 +25,11 @@ The ladder, strongest evidence first:
 
 Song.id is platform-neutral (plan 07 compatibility): the ISRC when the cluster
 has exactly one distinct ISRC, else 'song:' + sha1 of the sorted member
-ISRCs/track-ids. Never a bare Spotify id.
+ISRCs/track-ids. Never a bare Spotify id. Song ids are UNIQUE across the
+result: a manually-split cluster whose natural id collides with another
+cluster's (tracks sharing one ISRC — exactly the case a split override
+exists for) gets a deterministic ':split:' + sha1(member track ids) suffix,
+so the graph MERGE can never silently re-unite what the override tore apart.
 
 Stances (documented per the plan's open questions):
 - Re-recordings ("Taylor's Version") differ in ISRC and usually duration, so
@@ -70,6 +74,7 @@ class SongCluster:
     members: tuple
     heuristic_only: bool      # >1 member and nothing stronger than heuristics
     duration_spread_ms: int   # max - min member duration (0 when unknown)
+    split_derived: bool = False   # torn out by a manual split override
 
 
 @dataclass(frozen=True)
@@ -222,7 +227,9 @@ def cluster_tracks(records, overrides=None):
     clusters_by_root = defaultdict(list)
     for tid in by_id:
         clusters_by_root[uf.find(tid)].append(tid)
-    groups = [sorted(g) for g in clusters_by_root.values()]
+    # Each group carries a split_derived flag so split clusters can be marked
+    # (and their song ids de-collided) downstream.
+    groups = [(sorted(g), False) for g in clusters_by_root.values()]
 
     # Splits tear their tracks out into a Song of their own (group stays whole).
     for split_group in overrides.splits:
@@ -232,18 +239,16 @@ def cluster_tracks(records, overrides=None):
         if not known:
             continue
         known_set = set(known)
-        groups = [[t for t in g if t not in known_set] for g in groups]
-        groups.append(known)
+        groups = [([t for t in g if t not in known_set], split) for g, split in groups]
+        groups.append((known, True))
         manual_ids.update(known)
     # Deterministic regardless of input order: sort groups by first member.
-    groups = sorted([g for g in groups if g], key=lambda g: g[0])
+    groups = sorted([(g, split) for g, split in groups if g], key=lambda pair: pair[0][0])
 
     # --- Build SongClusters ------------------------------------------------
-    clusters = []
-    parent_lookup = {}   # (primary_artist_id, base normalized text) -> song_id
-    remix_members = []   # (song_id, primary_artist_id, base_text)
+    prelim = []   # (group, members, natural song_id, split_derived)
 
-    for group in groups:
+    for group, split_derived in groups:
         group_records = [by_id[t] for t in group]
         isrc_counts = Counter(r["isrc"] for r in group_records if r.get("isrc"))
         linked_in_group = {
@@ -296,7 +301,41 @@ def cluster_tracks(records, overrides=None):
             ))
 
         members = tuple(sorted(members, key=lambda m: m.track_id))
-        song_id = compute_song_id(members)
+        prelim.append((group, members, compute_song_id(members), split_derived))
+
+    # A split must actually split: when a manually-split cluster's natural id
+    # collides with another cluster's (tracks sharing one ISRC — exactly the
+    # case a split override exists for), suffix it with a stable hash of its
+    # member track ids. Distinct ids across clusters, deterministically, or
+    # the graph MERGE would silently re-unite what the override tore apart.
+    id_counts = Counter(song_id for _, _, song_id, _ in prelim)
+    resolved = []
+    for group, members, song_id, split_derived in prelim:
+        if split_derived and id_counts[song_id] > 1:
+            member_hash = sha1("|".join(m.track_id for m in members).encode("utf-8")).hexdigest()
+            unique_id = f"{song_id}:split:{member_hash}"
+            result.warnings.append(
+                f"Split cluster {group} shares its natural song id {song_id!r} with "
+                f"another cluster (shared ISRC); assigned distinct id {unique_id!r}."
+            )
+            song_id = unique_id
+        resolved.append((group, members, song_id, split_derived))
+
+    # Fail loudly rather than corrupt silently: duplicate ids past this point
+    # would MERGE distinct clusters onto one (:Song). Unreachable by
+    # construction (the ISRC tier unions everything sharing an ISRC, and split
+    # collisions were just suffixed), so any hit here is a logic bug.
+    remaining_dupes = sorted(
+        i for i, n in Counter(s for _, _, s, _ in resolved).items() if n > 1
+    )
+    if remaining_dupes:
+        raise ValueError(f"Duplicate song ids across clusters: {remaining_dupes}")
+
+    clusters = []
+    parent_lookup = {}   # (primary_artist_id, base normalized text) -> song_id
+    remix_members = []   # (song_id, primary_artist_id, base_text)
+
+    for group, members, song_id, split_derived in resolved:
         # Least-decorated display title: shortest original name, ties lexical.
         title = min((m.name or "" for m in members), key=lambda n: (len(n), n))
         durations = [m.duration_ms for m in members if m.duration_ms is not None]
@@ -309,6 +348,7 @@ def cluster_tracks(records, overrides=None):
             members=members,
             heuristic_only=heuristic_only,
             duration_spread_ms=spread,
+            split_derived=split_derived,
         ))
 
         for tid in group:

--- a/application/mastering/cluster.py
+++ b/application/mastering/cluster.py
@@ -30,8 +30,10 @@ ISRCs/track-ids. Never a bare Spotify id.
 Stances (documented per the plan's open questions):
 - Re-recordings ("Taylor's Version") differ in ISRC and usually duration, so
   they land as separate Songs, each kind 'canonical'. Deliberate.
-- From the graph, CREATED edges are unordered, so run.py sorts artist ids and
-  the lexicographically smallest serves as a stable primary-artist proxy.
+- The graph supplies artist_ids from t.artist_ids — the performing artists in
+  credit order, persisted by the insert Cyphers. Legacy nodes without that
+  field fall back to sorted CREATED-edge ids (unordered and polluted by album
+  artists), a weaker primary proxy until the ISRC backfill refreshes them.
 """
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field

--- a/application/mastering/cluster.py
+++ b/application/mastering/cluster.py
@@ -1,0 +1,332 @@
+"""The identity ladder (plan 03) as pure functions over plain dicts — no
+Neo4j, so the whole pipeline is unit-testable offline. run.py owns the graph
+I/O on either side.
+
+Input: track records, one dict per (:Track):
+
+    {
+        "id": "4uLU6...",            # Spotify track id (required)
+        "name": "Cathedral Bells - 2011 Remaster",
+        "isrc": "USMCK2600056" | None,
+        "linked_from_id": "7GhIk..." | None,   # Spotify track relinking
+        "duration_ms": 184000 | None,
+        "explicit": bool,
+        "artist_ids": ["art1", ...],    # first element = primary artist
+        "artist_names": ["Artist 1", ...],  # for feat-clause stripping
+    }
+
+The ladder, strongest evidence first:
+    1. ISRC exact groups              -> method 'isrc',        confidence 1.0
+    2. Spotify linked_from unions     -> method 'linked_from', confidence 0.95
+    3. Heuristic: same normalized title + same primary artist + duration
+       within +/-3s, blocked on (primary_artist_id, norm_title[:8])
+                                      -> method 'heuristic',   confidence 0.85
+    4. Manual overrides (win)         -> method 'manual',      confidence 1.0
+
+Song.id is platform-neutral (plan 07 compatibility): the ISRC when the cluster
+has exactly one distinct ISRC, else 'song:' + sha1 of the sorted member
+ISRCs/track-ids. Never a bare Spotify id.
+
+Stances (documented per the plan's open questions):
+- Re-recordings ("Taylor's Version") differ in ISRC and usually duration, so
+  they land as separate Songs, each kind 'canonical'. Deliberate.
+- From the graph, CREATED edges are unordered, so run.py sorts artist ids and
+  the lexicographically smallest serves as a stable primary-artist proxy.
+"""
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from hashlib import sha1
+
+from application.mastering.normalize import normalize
+from application.mastering.overrides import Overrides
+
+# Heuristic duration gate: variants of one recording sit within a few seconds;
+# same-titled *different* songs (intros, interludes, "Untitled") usually don't.
+DURATION_TOLERANCE_MS = 3000
+
+CONFIDENCE = {"isrc": 1.0, "linked_from": 0.95, "heuristic": 0.85, "manual": 1.0}
+
+# Blocking-key title prefix length (keeps heuristic comparisons local).
+_BLOCK_PREFIX = 8
+
+
+@dataclass(frozen=True)
+class Member:
+    track_id: str
+    kind: str          # canonical | remaster | live | ... | clean | explicit | remix
+    method: str        # isrc | linked_from | heuristic | manual
+    confidence: float
+    isrc: str = None
+    name: str = None
+    duration_ms: int = None
+
+
+@dataclass(frozen=True)
+class SongCluster:
+    song_id: str
+    title: str
+    members: tuple
+    heuristic_only: bool      # >1 member and nothing stronger than heuristics
+    duration_spread_ms: int   # max - min member duration (0 when unknown)
+
+
+@dataclass(frozen=True)
+class RemixEdge:
+    remix_song_id: str
+    parent_song_id: str
+    confidence: float
+
+
+@dataclass
+class MasteringResult:
+    clusters: list = field(default_factory=list)
+    remix_edges: list = field(default_factory=list)
+    warnings: list = field(default_factory=list)
+
+    @property
+    def multi_member_clusters(self):
+        return [c for c in self.clusters if len(c.members) > 1]
+
+
+class _UnionFind:
+    def __init__(self, ids):
+        self.parent = {i: i for i in ids}
+
+    def find(self, i):
+        root = i
+        while self.parent[root] != root:
+            root = self.parent[root]
+        while self.parent[i] != root:  # path compression
+            self.parent[i], i = root, self.parent[i]
+        return root
+
+    def union(self, a, b):
+        ra, rb = self.find(a), self.find(b)
+        if ra != rb:
+            # Deterministic: smaller id becomes the root.
+            lo, hi = sorted((ra, rb))
+            self.parent[hi] = lo
+
+
+def track_record_from_api(track):
+    """Convert a full Spotify track object (API/mock shape) into the plain
+    record cluster_tracks() consumes."""
+    return {
+        "id": track["id"],
+        "name": track.get("name"),
+        "isrc": (track.get("external_ids") or {}).get("isrc"),
+        "linked_from_id": (track.get("linked_from") or {}).get("id"),
+        "duration_ms": track.get("duration_ms"),
+        "explicit": bool(track.get("explicit")),
+        "artist_ids": [a["id"] for a in track.get("artists") or []],
+        "artist_names": [a.get("name") for a in track.get("artists") or []],
+    }
+
+
+def compute_song_id(members):
+    """The ISRC when the cluster has exactly one distinct ISRC; otherwise a
+    deterministic hash of the members. Never a bare Spotify id."""
+    isrcs = sorted({m.isrc for m in members if m.isrc})
+    if len(isrcs) == 1:
+        return isrcs[0]
+    keys = sorted(m.isrc or m.track_id for m in members)
+    return "song:" + sha1("|".join(keys).encode("utf-8")).hexdigest()
+
+
+def _primary_artist(record):
+    artist_ids = record.get("artist_ids") or []
+    return artist_ids[0] if artist_ids else None
+
+
+def cluster_tracks(records, overrides=None):
+    """Run the identity ladder over track records. Pure and deterministic:
+    the same input (in any order) yields the same MasteringResult."""
+    overrides = overrides or Overrides()
+    result = MasteringResult()
+
+    by_id = {}
+    for record in records:
+        if record["id"] in by_id:
+            result.warnings.append(f"Duplicate track record for id {record['id']}; keeping the first.")
+            continue
+        by_id[record["id"]] = record
+
+    norms = {
+        tid: normalize(rec.get("name"), rec.get("artist_names") or ())
+        for tid, rec in by_id.items()
+    }
+
+    uf = _UnionFind(sorted(by_id))
+    linked_ids = set()
+
+    # --- 1. ISRC exact groups --------------------------------------------
+    by_isrc = defaultdict(list)
+    for tid in sorted(by_id):
+        isrc = by_id[tid].get("isrc")
+        if isrc:
+            by_isrc[isrc].append(tid)
+    for group in by_isrc.values():
+        for other in group[1:]:
+            uf.union(group[0], other)
+
+    # --- 2. linked_from unions -------------------------------------------
+    for tid in sorted(by_id):
+        target = by_id[tid].get("linked_from_id")
+        if not target:
+            continue
+        if target in by_id:
+            uf.union(tid, target)
+            linked_ids.update((tid, target))
+        else:
+            result.warnings.append(
+                f"Track {tid} links from {target}, which is not in the graph; ignored."
+            )
+
+    # --- 3. Heuristic pass, blocked to keep comparisons local -------------
+    blocks = defaultdict(list)
+    for tid in sorted(by_id):
+        primary = _primary_artist(by_id[tid])
+        text = norms[tid].text
+        if primary and text:
+            blocks[(primary, text[:_BLOCK_PREFIX])].append(tid)
+    for block in blocks.values():
+        exact = defaultdict(list)
+        for tid in block:
+            exact[norms[tid].text].append(tid)
+        for group in exact.values():
+            if len(group) < 2:
+                continue
+            # Sort by duration and chain-union neighbors within tolerance, so
+            # a pathological far pair never merges directly (only via a chain,
+            # which the review report's duration-spread metric surfaces).
+            group = sorted(group, key=lambda t: (by_id[t].get("duration_ms") or 0, t))
+            for a, b in zip(group, group[1:]):
+                da, db = by_id[a].get("duration_ms"), by_id[b].get("duration_ms")
+                # Unknown durations do NOT merge — the gate is the only thing
+                # separating same-titled different songs, so stay conservative.
+                if da is not None and db is not None and abs(da - db) <= DURATION_TOLERANCE_MS:
+                    uf.union(a, b)
+
+    # --- 4. Manual overrides last (they win) ------------------------------
+    manual_ids = set()
+    for group in overrides.merges:
+        known = [t for t in group if t in by_id]
+        for missing in set(group) - set(known):
+            result.warnings.append(f"Merge override references unknown track {missing}; ignored.")
+        for other in known[1:]:
+            uf.union(known[0], other)
+        manual_ids.update(known)
+
+    clusters_by_root = defaultdict(list)
+    for tid in by_id:
+        clusters_by_root[uf.find(tid)].append(tid)
+    groups = [sorted(g) for g in clusters_by_root.values()]
+
+    # Splits tear their tracks out into a Song of their own (group stays whole).
+    for split_group in overrides.splits:
+        known = sorted(t for t in split_group if t in by_id)
+        for missing in set(split_group) - set(known):
+            result.warnings.append(f"Split override references unknown track {missing}; ignored.")
+        if not known:
+            continue
+        known_set = set(known)
+        groups = [[t for t in g if t not in known_set] for g in groups]
+        groups.append(known)
+        manual_ids.update(known)
+    # Deterministic regardless of input order: sort groups by first member.
+    groups = sorted([g for g in groups if g], key=lambda g: g[0])
+
+    # --- Build SongClusters ------------------------------------------------
+    clusters = []
+    parent_lookup = {}   # (primary_artist_id, base normalized text) -> song_id
+    remix_members = []   # (song_id, primary_artist_id, base_text)
+
+    for group in groups:
+        group_records = [by_id[t] for t in group]
+        isrc_counts = Counter(r["isrc"] for r in group_records if r.get("isrc"))
+        linked_in_group = {
+            t for t in group
+            if t in linked_ids and (
+                by_id[t].get("linked_from_id") in group
+                or any(by_id[o].get("linked_from_id") == t for o in group)
+            )
+        }
+
+        # Do explicit/clean twins coexist among the undecorated members?
+        canonical_explicit_flags = {
+            bool(by_id[t].get("explicit"))
+            for t in group
+            if norms[t].kind == "canonical"
+        }
+        has_explicit_twins = len(canonical_explicit_flags) > 1
+
+        members = []
+        for tid in group:
+            record, norm = by_id[tid], norms[tid]
+
+            if tid in manual_ids:
+                method = "manual"
+            elif record.get("isrc") and (isrc_counts[record["isrc"]] >= 2 or len(group) == 1):
+                method = "isrc"
+            elif tid in linked_in_group:
+                method = "linked_from"
+            else:
+                method = "heuristic"
+            confidence = 1.0 if len(group) == 1 else CONFIDENCE[method]
+
+            if norm.is_remix:
+                kind = "remix"
+            elif norm.kind != "canonical":
+                kind = norm.kind
+            elif has_explicit_twins:
+                kind = "explicit" if record.get("explicit") else "clean"
+            else:
+                kind = "canonical"
+
+            members.append(Member(
+                track_id=tid,
+                kind=kind,
+                method=method,
+                confidence=confidence,
+                isrc=record.get("isrc"),
+                name=record.get("name"),
+                duration_ms=record.get("duration_ms"),
+            ))
+
+        members = tuple(sorted(members, key=lambda m: m.track_id))
+        song_id = compute_song_id(members)
+        # Least-decorated display title: shortest original name, ties lexical.
+        title = min((m.name or "" for m in members), key=lambda n: (len(n), n))
+        durations = [m.duration_ms for m in members if m.duration_ms is not None]
+        spread = max(durations) - min(durations) if durations else 0
+        heuristic_only = len(members) > 1 and all(m.method == "heuristic" for m in members)
+
+        clusters.append(SongCluster(
+            song_id=song_id,
+            title=title,
+            members=members,
+            heuristic_only=heuristic_only,
+            duration_spread_ms=spread,
+        ))
+
+        for tid in group:
+            norm = norms[tid]
+            primary = _primary_artist(by_id[tid])
+            if norm.is_remix:
+                remix_members.append((song_id, primary, norm.base_text))
+            elif primary and norm.text:
+                parent_lookup.setdefault((primary, norm.text), song_id)
+
+    # --- (:Song)-[:REMIX_OF]->(:Song) where the parent is resolvable -------
+    seen_edges = set()
+    for song_id, primary, base_text in remix_members:
+        parent = parent_lookup.get((primary, base_text))
+        if parent and parent != song_id and (song_id, parent) not in seen_edges:
+            seen_edges.add((song_id, parent))
+            result.remix_edges.append(RemixEdge(
+                remix_song_id=song_id, parent_song_id=parent, confidence=0.9,
+            ))
+
+    result.clusters = sorted(clusters, key=lambda c: c.song_id)
+    result.remix_edges.sort(key=lambda e: (e.remix_song_id, e.parent_song_id))
+    return result

--- a/application/mastering/normalize.py
+++ b/application/mastering/normalize.py
@@ -1,0 +1,171 @@
+"""Title normalization for entity mastering (plan 03) — the heart of the
+heuristic tier of the identity ladder.
+
+normalize() reduces a track title to the comparison key used for clustering,
+recording WHAT was stripped as the variant kind. Deliberate stances:
+
+- Remix credits are NEVER stripped: "(Artist B Remix)" is a different song in
+  DJ reality. The credit stays inside the normalized text (so a remix can never
+  merge with its parent) and is surfaced via remix_credit / base_text so the
+  clustering layer can emit (:Song)-[:REMIX_OF]->(:Song) edges.
+- feat./featuring/with clauses are stripped only when the featured name is
+  already among the track's credited artists — otherwise the clause is signal
+  and stays in the title.
+- Re-recordings ("Taylor's Version" pattern) share title + artist but differ in
+  ISRC and usually duration; they land as separate Songs, each kind
+  'canonical'. That is deliberate: a re-recording is a different recording.
+"""
+import re
+import unicodedata
+from dataclasses import dataclass
+
+# Suffix decorations: end-anchored, stripped repeatedly until fixpoint so
+# stacked suffixes ("Song - Single Version - 2011 Remaster") all come off.
+# Each strip records its kind. Order decides which kind is recorded first for
+# a stacked title (outermost decoration strips first).
+_DECORATION_PATTERNS = [
+    # "- 2011 Remaster", "- Remastered 2009", "(Remastered)", "(2011 Remaster)"
+    ("remaster", re.compile(r"\s*-\s*(?:\d{4}\s+)?remaster(?:ed)?(?:\s+\d{4})?\s*$")),
+    ("remaster", re.compile(r"\s*[(\[]\s*(?:\d{4}\s+)?remaster(?:ed)?(?:\s+\d{4})?\s*[)\]]\s*$")),
+    # "- Deluxe Edition", "(Deluxe ...)"
+    ("deluxe", re.compile(r"\s*-\s*deluxe(?:\s+edition)?\s*$")),
+    ("deluxe", re.compile(r"\s*[(\[]\s*deluxe[^)\]]*[)\]]\s*$")),
+    # "(Expanded ...)"
+    ("expanded", re.compile(r"\s*-\s*expanded(?:\s+edition)?\s*$")),
+    ("expanded", re.compile(r"\s*[(\[]\s*expanded[^)\]]*[)\]]\s*$")),
+    # "- Single Version"
+    ("single_version", re.compile(r"\s*-\s*single\s+version\s*$")),
+    ("single_version", re.compile(r"\s*[(\[]\s*single\s+version\s*[)\]]\s*$")),
+    # "- Radio Edit"
+    ("radio_edit", re.compile(r"\s*-\s*radio\s+edit\s*$")),
+    ("radio_edit", re.compile(r"\s*[(\[]\s*radio\s+edit\s*[)\]]\s*$")),
+    # "- Bonus Track"
+    ("bonus_track", re.compile(r"\s*-\s*bonus\s+track\s*$")),
+    ("bonus_track", re.compile(r"\s*[(\[]\s*bonus\s+track\s*[)\]]\s*$")),
+    # "- Live", "- Live at Wembley", "(Live from ...)"
+    ("live", re.compile(r"\s*-\s*live(?:\s+(?:at|from|in)\s+.*)?\s*$")),
+    ("live", re.compile(r"\s*[(\[]\s*live(?:\s+(?:at|from|in)\s+[^)\]]*)?\s*[)\]]\s*$")),
+    # "- Demo", "(Demo Version)"
+    ("demo", re.compile(r"\s*-\s*demo(?:\s+version)?\s*$")),
+    ("demo", re.compile(r"\s*[(\[]\s*demo(?:\s+version)?\s*[)\]]\s*$")),
+]
+
+# Remix markers. The credit (possibly empty, e.g. "(Remix)") is extracted so
+# the marker survives normalization in a canonical form and REMIX_OF parents
+# can be resolved from base_text.
+_REMIX_PATTERNS = [
+    re.compile(r"\s*[(\[]\s*([^()\[\]]*?)\s*remix\s*[)\]]\s*$"),
+    re.compile(r"\s*-\s*(.*?)\s*remix\s*$"),
+]
+
+# feat./featuring/with clauses — parenthesized anywhere-at-end, or a bare
+# trailing "feat." clause. Unparenthesized "with" is deliberately NOT matched
+# ("Dancing With Myself" is a title, not a credit).
+_FEAT_PATTERNS = [
+    re.compile(r"\s*[(\[]\s*(?:feat\.?|ft\.?|featuring|with)\s+([^)\]]+?)\s*[)\]]\s*$"),
+    re.compile(r"\s*-\s*(?:feat\.?|ft\.?|featuring)\s+(.+?)\s*$"),
+    re.compile(r"\s+(?:feat\.?|ft\.?|featuring)\s+(.+?)\s*$"),
+]
+
+_APOSTROPHES = re.compile(r"['’ʼ]")
+_NON_ALNUM = re.compile(r"[^0-9a-z]+")
+
+
+def _scrub(text):
+    """Unicode NFKD -> drop combining marks -> drop apostrophes (don't -> dont)
+    -> collapse punctuation/whitespace runs to single spaces."""
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(ch for ch in text if not unicodedata.combining(ch))
+    text = _APOSTROPHES.sub("", text)
+    return _NON_ALNUM.sub(" ", text).strip()
+
+
+def _artist_in_clause(clause, artist_names):
+    """True when any credited artist appears in the featured-credit clause."""
+    clause_scrubbed = f" {_scrub(clause.lower())} "
+    for name in artist_names:
+        name_scrubbed = _scrub(str(name).lower())
+        if name_scrubbed and f" {name_scrubbed} " in clause_scrubbed:
+            return True
+    return False
+
+
+@dataclass(frozen=True)
+class NormalizedTitle:
+    text: str                 # the comparison key (remix credit retained)
+    base_text: str            # text minus the remix marker (== text if no remix)
+    kind: str                 # 'remix' | first stripped decoration | 'canonical'
+    kinds: tuple = ()         # every decoration kind stripped, in strip order
+    remix_credit: str = None  # None = not a remix; may be "" ("(Remix)")
+
+    @property
+    def is_remix(self):
+        return self.remix_credit is not None
+
+
+def normalize(title, artist_names=()):
+    """Normalize a track title for song-identity comparison.
+
+    artist_names: the track's credited artist names — needed to decide whether
+    a feat./featuring clause is redundant (strippable) or signal (kept).
+    """
+    working = (title or "").lower().strip()
+
+    kinds = []
+    remix_credit = None
+
+    # Strip end-anchored decorations until fixpoint. Remix markers are pulled
+    # OUT (and remembered) rather than dropped, so an inner decoration behind
+    # one ("Song (X Remix) - Radio Edit") still strips.
+    changed = True
+    while changed and working:
+        changed = False
+
+        for kind, pattern in _DECORATION_PATTERNS:
+            new = pattern.sub("", working)
+            if new != working:
+                kinds.append(kind)
+                working = new
+                changed = True
+                break
+        if changed:
+            continue
+
+        if remix_credit is None:  # only the outermost remix marker is the credit
+            for pattern in _REMIX_PATTERNS:
+                match = pattern.search(working)
+                if match:
+                    remix_credit = match.group(1).strip()
+                    working = working[:match.start()]
+                    changed = True
+                    break
+            if changed:
+                continue
+
+        for pattern in _FEAT_PATTERNS:
+            match = pattern.search(working)
+            if match and _artist_in_clause(match.group(1), artist_names):
+                working = working[:match.start()]
+                changed = True
+                break
+
+    base_text = _scrub(working)
+    if remix_credit is not None:
+        text = _scrub(f"{base_text} {remix_credit} remix")
+    else:
+        text = base_text
+
+    if remix_credit is not None:
+        kind = "remix"
+    elif kinds:
+        kind = kinds[0]
+    else:
+        kind = "canonical"
+
+    return NormalizedTitle(
+        text=text,
+        base_text=base_text,
+        kind=kind,
+        kinds=tuple(kinds),
+        remix_credit=remix_credit,
+    )

--- a/application/mastering/normalize.py
+++ b/application/mastering/normalize.py
@@ -53,9 +53,15 @@ _DECORATION_PATTERNS = [
 # Remix markers. The credit (possibly empty, e.g. "(Remix)") is extracted so
 # the marker survives normalization in a canonical form and REMIX_OF parents
 # can be resolved from base_text.
+#
+# The hyphen form anchors at the LAST whitespace-delimited " - " separator:
+# the greedy <base> pushes the match rightward, and requiring whitespace on
+# both sides keeps internal hyphens ("Re-Wired", "T-Shirt", "Jay-Z") inside
+# the base/credit instead of truncating the base at the first hyphen (which
+# missed the real REMIX_OF parent — or hit a wrong one).
 _REMIX_PATTERNS = [
-    re.compile(r"\s*[(\[]\s*([^()\[\]]*?)\s*remix\s*[)\]]\s*$"),
-    re.compile(r"\s*-\s*(.*?)\s*remix\s*$"),
+    re.compile(r"\s*[(\[]\s*(?P<credit>[^()\[\]]*?)\s*remix\s*[)\]]\s*$"),
+    re.compile(r"^(?P<base>.*\S)\s+-\s+(?P<credit>.*?)\s*remix\s*$"),
 ]
 
 # feat./featuring/with clauses — parenthesized anywhere-at-end, or a bare
@@ -135,8 +141,15 @@ def normalize(title, artist_names=()):
             for pattern in _REMIX_PATTERNS:
                 match = pattern.search(working)
                 if match:
-                    remix_credit = match.group(1).strip()
-                    working = working[:match.start()]
+                    remix_credit = match.group("credit").strip()
+                    groups = match.groupdict()
+                    # Hyphen form: the base is the greedy prefix before the
+                    # LAST " - " separator. Paren form: everything before the
+                    # end-anchored marker.
+                    if "base" in groups:
+                        working = groups["base"]
+                    else:
+                        working = working[:match.start()]
                     changed = True
                     break
             if changed:

--- a/application/mastering/overrides.example.yaml
+++ b/application/mastering/overrides.example.yaml
@@ -1,0 +1,22 @@
+# Manual entity-mastering overrides (plan 03) — forced merges and splits that
+# beat every heuristic. Copy this file to secrets/mastering_overrides.yaml (or
+# point the MASTERING_OVERRIDES_PATH env var anywhere) and rerun
+# `python -m application.mastering.run`; overrides are applied LAST, so they
+# always win. The review report (data/mastering_review.md) is where you find
+# the track ids to put here.
+
+# merge: each entry forces every listed Spotify track id into ONE Song,
+# regardless of ISRC/title/duration evidence. Members get
+# VERSION_OF {method: 'manual', confidence: 1.0}.
+merge:
+  - tracks: [4uLU6hMCjMI75M1A2tKUQC, 7GhIk7Il098yCjg4BQjzvb]
+    reason: "same recording, label re-registered the ISRC on the reissue"
+  # Bare lists work too:
+  # - [4uLU6hMCjMI75M1A2tKUQC, 7GhIk7Il098yCjg4BQjzvb]
+
+# split: each entry tears the listed track ids OUT of whatever cluster the
+# heuristics put them in, into a Song of their own. The listed group stays
+# together (a one-id list means "this track stands alone").
+split:
+  - tracks: [2takcwOaAZWiXQijPHIx7B]
+    reason: "same title + duration as the album cut, but it's a re-recording"

--- a/application/mastering/overrides.py
+++ b/application/mastering/overrides.py
@@ -1,0 +1,73 @@
+"""Manual mastering overrides: forced merges and splits, because the
+heuristics WILL be wrong somewhere and Michael will notice.
+
+The overrides file lives outside the repo (default: secrets/
+mastering_overrides.yaml, path overridable via the MASTERING_OVERRIDES_PATH
+env var); a documented example is tracked at
+application/mastering/overrides.example.yaml. A missing file means "no
+overrides" — never an error, so the batch job runs before any override has
+ever been written.
+"""
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+from application.loggers import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class Overrides:
+    # Each inner list is a group of Spotify track ids forced into ONE Song.
+    merges: list = field(default_factory=list)
+    # Each inner list is a group of track ids torn OUT of whatever cluster the
+    # heuristics placed them in, into a Song of their own (the group itself
+    # stays together — a singleton list means "this track stands alone").
+    splits: list = field(default_factory=list)
+
+    def __bool__(self):
+        return bool(self.merges or self.splits)
+
+
+def _groups(entries, section):
+    """Accept both `- tracks: [a, b]` mappings and bare `- [a, b]` lists."""
+    groups = []
+    for entry in entries or []:
+        if isinstance(entry, dict):
+            tracks = entry.get("tracks")
+        else:
+            tracks = entry
+        if not isinstance(tracks, list) or not all(isinstance(t, str) for t in tracks):
+            raise ValueError(
+                f"Malformed {section} override entry (want a list of track ids "
+                f"or a mapping with a 'tracks' list): {entry!r}"
+            )
+        if tracks:
+            groups.append(list(tracks))
+    return groups
+
+
+def load_overrides(path):
+    """Load forced merges/splits from a YAML file; missing file -> empty."""
+    path = Path(path)
+    if not path.exists():
+        logger.info(f"No mastering overrides file at {path}; proceeding without overrides.")
+        return Overrides()
+
+    with open(path, "r") as f:
+        raw = yaml.safe_load(f) or {}
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"Overrides file {path} must be a mapping with 'merge'/'split' keys.")
+
+    overrides = Overrides(
+        merges=_groups(raw.get("merge"), "merge"),
+        splits=_groups(raw.get("split"), "split"),
+    )
+    logger.info(
+        f"Loaded mastering overrides from {path}: "
+        f"{len(overrides.merges)} merge group(s), {len(overrides.splits)} split group(s)."
+    )
+    return overrides

--- a/application/mastering/report.py
+++ b/application/mastering/report.py
@@ -1,0 +1,120 @@
+"""Human review report for a mastering run (plan 03 T6).
+
+Renders the clusters formed this run as markdown, sorted by descending
+ambiguity — heuristic-only clusters with a duration spread over one second
+first, since those are exactly where the heuristics are most likely wrong.
+The loop: skim data/mastering_review.md, add overrides, rerun.
+"""
+from datetime import datetime, timezone
+
+from application.config import DATA_DIR
+from application.loggers import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_REPORT_PATH = DATA_DIR / "mastering_review.md"
+AMBIGUOUS_SPREAD_MS = 1000
+
+
+def _ambiguity_key(cluster):
+    """Sort key: most-review-worthy first."""
+    return (
+        # 1. heuristic-only AND spread > 1s (plan-specified top of the report)
+        not (cluster.heuristic_only and cluster.duration_spread_ms > AMBIGUOUS_SPREAD_MS),
+        # 2. any heuristic-only cluster
+        not cluster.heuristic_only,
+        # 3. wider duration spreads before tighter ones
+        -cluster.duration_spread_ms,
+        # 4. stable tie-break
+        cluster.song_id,
+    )
+
+
+def _cluster_section(cluster):
+    methods = sorted({m.method for m in cluster.members})
+    flags = []
+    if cluster.heuristic_only:
+        flags.append("heuristic-only")
+    if cluster.duration_spread_ms > AMBIGUOUS_SPREAD_MS:
+        flags.append(f"duration spread {cluster.duration_spread_ms} ms")
+    flag_text = f" — **{', '.join(flags)}**" if flags else ""
+
+    lines = [
+        f"### `{cluster.song_id}` — {cluster.title}{flag_text}",
+        "",
+        f"{len(cluster.members)} versions · methods: {', '.join(methods)}",
+        "",
+        "| track id | title | kind | method | confidence | duration (ms) | isrc |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for m in cluster.members:
+        lines.append(
+            f"| `{m.track_id}` | {m.name or ''} | {m.kind} | {m.method} "
+            f"| {m.confidence:.2f} | {m.duration_ms if m.duration_ms is not None else '?'} "
+            f"| {m.isrc or '—'} |"
+        )
+    lines.append("")
+    return lines
+
+
+def render_review_report(result, now=None):
+    """Render a MasteringResult to markdown (ambiguity-sorted)."""
+    now = now or datetime.now(timezone.utc)
+    multi = sorted(result.multi_member_clusters, key=_ambiguity_key)
+    singletons = len(result.clusters) - len(multi)
+    review_first = [
+        c for c in multi
+        if c.heuristic_only and c.duration_spread_ms > AMBIGUOUS_SPREAD_MS
+    ]
+
+    lines = [
+        "# Mastering review",
+        "",
+        f"_Generated {now.strftime('%Y-%m-%d %H:%M:%S %Z')} by "
+        f"`python -m application.mastering.run`._",
+        "",
+        f"- **{len(result.clusters)}** Songs "
+        f"({len(multi)} with multiple versions, {singletons} singletons)",
+        f"- **{sum(len(c.members) for c in result.clusters)}** Tracks assigned",
+        f"- **{len(result.remix_edges)}** REMIX_OF edges",
+        f"- **{len(review_first)}** clusters flagged for review "
+        f"(heuristic-only, duration spread > {AMBIGUOUS_SPREAD_MS} ms)",
+        "",
+        "Wrong merge? Wrong split? Add the track ids to the overrides file",
+        "(see `application/mastering/overrides.example.yaml`) and rerun — ",
+        "overrides always win.",
+        "",
+    ]
+
+    if result.warnings:
+        lines += ["## Warnings", ""]
+        lines += [f"- {w}" for w in result.warnings]
+        lines.append("")
+
+    lines += ["## Clusters (most ambiguous first)", ""]
+    if multi:
+        for cluster in multi:
+            lines += _cluster_section(cluster)
+    else:
+        lines += ["_No multi-version clusters were formed this run._", ""]
+
+    if result.remix_edges:
+        lines += ["## Remix edges", ""]
+        lines += [
+            f"- `{e.remix_song_id}` -REMIX_OF-> `{e.parent_song_id}` "
+            f"(confidence {e.confidence:.2f})"
+            for e in result.remix_edges
+        ]
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def write_review_report(result, output_path=None):
+    """Render and write the report; returns the path written."""
+    output_path = output_path or DEFAULT_REPORT_PATH
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        f.write(render_review_report(result))
+    logger.info(f"Wrote mastering review report to {output_path}")
+    return output_path

--- a/application/mastering/report.py
+++ b/application/mastering/report.py
@@ -33,6 +33,8 @@ def _ambiguity_key(cluster):
 def _cluster_section(cluster):
     methods = sorted({m.method for m in cluster.members})
     flags = []
+    if cluster.split_derived:
+        flags.append("manual split")
     if cluster.heuristic_only:
         flags.append("heuristic-only")
     if cluster.duration_spread_ms > AMBIGUOUS_SPREAD_MS:
@@ -97,6 +99,20 @@ def render_review_report(result, now=None):
             lines += _cluster_section(cluster)
     else:
         lines += ["_No multi-version clusters were formed this run._", ""]
+
+    # Split-derived Songs are usually singletons (which get no cluster section
+    # of their own), so list every one here — the reviewer can confirm the
+    # override actually took effect (and spot the ':split:'-suffixed ids the
+    # shared-ISRC case produces).
+    split_clusters = [c for c in result.clusters if c.split_derived]
+    if split_clusters:
+        lines += ["## Manual splits", ""]
+        lines += [
+            f"- `{c.song_id}` — {c.title} "
+            f"({', '.join(f'`{m.track_id}`' for m in c.members)})"
+            for c in split_clusters
+        ]
+        lines.append("")
 
     if result.remix_edges:
         lines += ["## Remix edges", ""]

--- a/application/mastering/run.py
+++ b/application/mastering/run.py
@@ -1,0 +1,136 @@
+"""The entity-mastering batch job (plan 03 T5/T6): offline, idempotent,
+re-runnable after every crawl.
+
+    python -m application.mastering.run
+
+1. Read every non-local (:Track) (with sorted artist ids/names) from Neo4j.
+2. Run the identity ladder (see cluster.py) with manual overrides applied
+   last — overrides load from MASTERING_OVERRIDES_PATH (default:
+   secrets/mastering_overrides.yaml; missing file = no overrides).
+3. MERGE (:Song) + (:Track)-[:VERSION_OF {kind, confidence, method}]->(:Song)
+   (exactly one per Track — reassignment re-points the edge, never deletes a
+   Song) and (:Song)-[:REMIX_OF {confidence}]->(:Song).
+4. Emit the ambiguity-sorted review report to data/mastering_review.md.
+
+Not in the crawl path: run it by hand (or a one-off container) whenever the
+graph has grown. Requires tracks to carry `isrc` — run
+`python -m application.mastering.backfill` first after upgrading old graphs.
+"""
+import os
+
+from application.config import APPLICATION_DIR, SECRETS_DIR
+from application.graph_database.connect import connect_to_neo4j, execute_query_against_neo4j
+from application.graph_database.initialize_database_environment import initialize_database_environment
+from application.loggers import get_logger
+from application.mastering.cluster import cluster_tracks
+from application.mastering.overrides import load_overrides
+from application.mastering.report import write_review_report
+
+logger = get_logger(__name__)
+
+MASTERING_QUERIES_DIR = APPLICATION_DIR / "graph_database" / "queries" / "mastering"
+NEO4J_CREDENTIALS_FILE = SECRETS_DIR / "neo4j_credentials.yaml"
+DEFAULT_OVERRIDES_PATH = SECRETS_DIR / "mastering_overrides.yaml"
+
+# Keep UNWIND payloads a sane size for one transaction.
+CLUSTER_WRITE_BATCH_SIZE = 500
+
+
+def _read_query(filename):
+    with open(MASTERING_QUERIES_DIR / filename, "r") as f:
+        return f.read()
+
+
+def overrides_path_from_env():
+    return os.environ.get("MASTERING_OVERRIDES_PATH", str(DEFAULT_OVERRIDES_PATH))
+
+
+def fetch_track_records(driver, database="neo4j"):
+    """Read the clustering input records out of the graph."""
+    records, _, _ = driver.execute_query(
+        _read_query("fetch_tracks_for_mastering.cypher"), database_=database
+    )
+    return [record.data() for record in records]
+
+
+def write_mastering_result(result, driver, database="neo4j"):
+    """MERGE Songs + VERSION_OF (batched), then REMIX_OF edges."""
+    clusters_param = [
+        {
+            "song_id": c.song_id,
+            "title": c.title,
+            "members": [
+                {
+                    "track_id": m.track_id,
+                    "kind": m.kind,
+                    "method": m.method,
+                    "confidence": m.confidence,
+                }
+                for m in c.members
+            ],
+        }
+        for c in result.clusters
+    ]
+
+    merge_clusters = _read_query("merge_song_clusters.cypher")
+    for start in range(0, len(clusters_param), CLUSTER_WRITE_BATCH_SIZE):
+        batch = clusters_param[start:start + CLUSTER_WRITE_BATCH_SIZE]
+        logger.info(f"Writing Song clusters {start + 1}..{start + len(batch)} of {len(clusters_param)}")
+        execute_query_against_neo4j(
+            query=merge_clusters, driver=driver, database=database, clusters=batch
+        )
+
+    edges_param = [
+        {
+            "remix_song_id": e.remix_song_id,
+            "parent_song_id": e.parent_song_id,
+            "confidence": e.confidence,
+        }
+        for e in result.remix_edges
+    ]
+    if edges_param:
+        execute_query_against_neo4j(
+            query=_read_query("merge_remix_of.cypher"),
+            driver=driver, database=database, edges=edges_param,
+        )
+
+
+def run_mastering(driver, database="neo4j", overrides_path=None, report_path=None):
+    """The whole batch against an existing driver; returns the MasteringResult."""
+    overrides = load_overrides(overrides_path or overrides_path_from_env())
+
+    records = fetch_track_records(driver, database=database)
+    logger.info(f"Fetched {len(records)} track records for mastering.")
+    without_isrc = sum(1 for r in records if not r.get("isrc"))
+    if without_isrc:
+        logger.warning(
+            f"{without_isrc}/{len(records)} tracks have no isrc — consider running "
+            f"`python -m application.mastering.backfill` first."
+        )
+
+    result = cluster_tracks(records, overrides)
+    for warning in result.warnings:
+        logger.warning(warning)
+    logger.info(
+        f"Formed {len(result.clusters)} Songs "
+        f"({len(result.multi_member_clusters)} multi-version) and "
+        f"{len(result.remix_edges)} REMIX_OF edges."
+    )
+
+    write_mastering_result(result, driver, database=database)
+    report_file = write_review_report(result, output_path=report_path)
+    logger.info(f"Done. Review report: {report_file}")
+    return result
+
+
+def main():
+    driver = connect_to_neo4j(NEO4J_CREDENTIALS_FILE)
+    try:
+        initialize_database_environment(driver=driver)  # Song.id uniqueness
+        run_mastering(driver)
+    finally:
+        driver.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/application/mastering/run.py
+++ b/application/mastering/run.py
@@ -17,6 +17,7 @@ graph has grown. Requires tracks to carry `isrc` — run
 `python -m application.mastering.backfill` first after upgrading old graphs.
 """
 import os
+from collections import Counter
 
 from application.config import APPLICATION_DIR, SECRETS_DIR
 from application.graph_database.connect import connect_to_neo4j, execute_query_against_neo4j
@@ -71,6 +72,21 @@ def write_mastering_result(result, driver, database="neo4j"):
         }
         for c in result.clusters
     ]
+
+    # Belt and suspenders (cluster_tracks already guarantees uniqueness): two
+    # clusters sharing a song_id would MERGE onto the same (:Song), silently
+    # undoing a manual split. Refuse the whole payload before any graph I/O —
+    # fail loudly over corrupt silently.
+    duplicate_ids = sorted(
+        song_id
+        for song_id, count in Counter(c["song_id"] for c in clusters_param).items()
+        if count > 1
+    )
+    if duplicate_ids:
+        raise ValueError(
+            f"Refusing to write mastering result: duplicate Song ids across "
+            f"clusters {duplicate_ids} would merge distinct clusters onto one (:Song)."
+        )
 
     merge_clusters = _read_query("merge_song_clusters.cypher")
     for start in range(0, len(clusters_param), CLUSTER_WRITE_BATCH_SIZE):

--- a/mock_spotify/catalog.py
+++ b/mock_spotify/catalog.py
@@ -25,6 +25,46 @@ def _n(prefix, identifier):
     return int(suffix) if suffix.isdigit() else None
 
 
+def _isrc(i):
+    """Deterministic ISRC for track i (CC-XXX-YY-NNNNN, mock registrant MCK)."""
+    return f"USMCK26{i:05d}"
+
+
+# ---------------------------------------------------------------------------
+# Entity-mastering variant cases (plan 03). Fixed track indices near the top of
+# the default catalog (requires MOCK_N_TRACKS >= 59, default 60) whose fields
+# deviate from the generated pattern so tests can exercise the identity ladder:
+#
+#   52/53  deluxe re-release pair -- two track ids SHARING one ISRC (labels
+#          reuse the ISRC when a deluxe edition re-ships the same recording)
+#   54/55  explicit/clean twins   -- different ISRCs, same title + primary
+#          artist, durations within +/-3s (heuristic-tier merge)
+#   56/57  remaster + original    -- different ISRCs; 56 carries the
+#          " - 2011 Remaster" suffix normalize() must strip (kind: remaster)
+#   58     "(Nightcrawler Remix)" -- a remix of 56/57's song that must NOT
+#          merge with it (remix credits are never stripped); duration is
+#          deliberately within tolerance to tempt a naive matcher
+#
+# All variants share primary artist 3 so the heuristic blocking key
+# (primary_artist_id, normalized-title prefix) actually groups them.
+# ---------------------------------------------------------------------------
+VARIANTS = {
+    52: {"name": "Neon Skyline", "isrc": _isrc(52), "artist_i": 3},
+    53: {"name": "Neon Skyline", "isrc": _isrc(52), "artist_i": 3},
+    54: {"name": "Gutter Anthem", "explicit": True, "artist_i": 3, "duration_ms": 201000},
+    55: {"name": "Gutter Anthem", "explicit": False, "artist_i": 3, "duration_ms": 200000},
+    56: {"name": "Cathedral Bells - 2011 Remaster", "artist_i": 3, "duration_ms": 184000},
+    57: {"name": "Cathedral Bells", "artist_i": 3, "duration_ms": 183000},
+    58: {"name": "Cathedral Bells (Nightcrawler Remix)", "artist_i": 3, "duration_ms": 184500},
+}
+
+# Convenience ids for tests (hit these via GET /v1/tracks?ids=...).
+DELUXE_PAIR_IDS = ("trk000052", "trk000053")
+CLEAN_EXPLICIT_TWIN_IDS = ("trk000054", "trk000055")
+REMASTER_PAIR_IDS = ("trk000056", "trk000057")
+REMIX_TRACK_ID = "trk000058"
+
+
 def artist(i):
     aid = f"art{i % N_ARTISTS:06d}"
     return {
@@ -60,19 +100,22 @@ def album(i):
 
 def track(i):
     tid = f"trk{i:06d}"
+    v = VARIANTS.get(i, {})
     return {
         "uri": f"spotify:track:{tid}",
         "id": tid,
-        "name": f"Track {i}",
-        "explicit": False,
+        "name": v.get("name", f"Track {i}"),
+        "explicit": v.get("explicit", False),
         "is_local": False,
-        "duration_ms": 200000,
+        "duration_ms": v.get("duration_ms", 200000),
         "popularity": 50,
         "type": "track",
         "href": f"{PUBLIC_BASE_URL}/v1/tracks/{tid}",
         "external_urls": {"spotify": f"https://open.spotify.com/track/{tid}"},
+        "external_ids": {"isrc": v.get("isrc", _isrc(i))},
         "album": album(i),          # track i lives on album (i % N_ALBUMS)
-        "artists": [artist(i)],     # plus its own performing artist
+        # The performing artist (variants pin a shared primary artist).
+        "artists": [artist(v.get("artist_i", i))],
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,8 +40,10 @@ def _album(i, artists=None):
     }
 
 
-def _track(i, album=None, artists=None):
-    return {
+def _track(i, album=None, artists=None, isrc=None, linked_from_id=None):
+    """isrc: None -> deterministic default; "" -> omit external_ids entirely
+    (a very old/indie release without one)."""
+    track = {
         "uri": f"spotify:track:{i}",
         "id": f"trk{i}",
         "name": f"Track {i}",
@@ -55,6 +57,15 @@ def _track(i, album=None, artists=None):
         "album": _album(i) if album is None else album,
         "artists": [_artist(i)] if artists is None else artists,
     }
+    if isrc != "":
+        track["external_ids"] = {"isrc": f"ISRC{i}" if isrc is None else isrc}
+    if linked_from_id is not None:
+        track["linked_from"] = {
+            "id": linked_from_id,
+            "uri": f"spotify:track:{linked_from_id}",
+            "type": "track",
+        }
+    return track
 
 
 def _liked_page(tracks, offset=0, next_url=None):

--- a/tests/test_mastering_backfill.py
+++ b/tests/test_mastering_backfill.py
@@ -1,0 +1,119 @@
+"""Offline unit tests for the ISRC backfill script (plan 03 T3). The HTTP
+layer is injected, so no live Spotify (or mock service) is needed; the
+Neo4j-facing pieces are covered in test_mastering_e2e.py behind the skip
+fixture."""
+import pytest
+import requests
+
+from application.mastering.backfill import (
+    BATCH_SIZE,
+    MAX_429_RETRIES,
+    MAX_RETRY_AFTER_SECONDS,
+    chunked,
+    fetch_tracks_batch,
+)
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None, headers=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.headers = headers or {}
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(f"HTTP {self.status_code}")
+
+
+def test_chunked_splits_at_batch_size():
+    ids = [f"t{i}" for i in range(BATCH_SIZE * 2 + 3)]
+    batches = chunked(ids)
+    assert [len(b) for b in batches] == [BATCH_SIZE, BATCH_SIZE, 3]
+    assert [i for b in batches for i in b] == ids
+
+
+def test_chunked_empty():
+    assert chunked([]) == []
+
+
+def test_fetch_tracks_batch_builds_the_batch_url_and_filters_nulls(make):
+    calls = []
+
+    def http_get(url, headers=None):
+        calls.append((url, headers))
+        return FakeResponse(payload={"tracks": [make.track(1), None, make.track(2)]})
+
+    tracks = fetch_tracks_batch(["trk1", "gone", "trk2"], http_get=http_get, token="tok")
+    assert [t["id"] for t in tracks] == ["trk1", "trk2"]  # nulls dropped
+    url, headers = calls[0]
+    assert url.endswith("/v1/tracks?ids=trk1,gone,trk2")
+    assert headers == {"Authorization": "Bearer tok"}
+
+
+def test_fetch_tracks_batch_retries_429_honoring_capped_retry_after(make):
+    responses = [
+        FakeResponse(status_code=429, headers={"Retry-After": "7"}),
+        FakeResponse(status_code=429, headers={"Retry-After": str(10**6)}),  # punitive
+        FakeResponse(payload={"tracks": [make.track(1)]}),
+    ]
+    waits = []
+    tracks = fetch_tracks_batch(
+        ["trk1"], http_get=lambda url, headers=None: responses.pop(0),
+        token="tok", wait=waits.append,
+    )
+    assert len(tracks) == 1
+    assert waits == [7, MAX_RETRY_AFTER_SECONDS]  # honored, then capped
+
+
+def test_fetch_tracks_batch_gives_up_after_max_429s():
+    def http_get(url, headers=None):
+        return FakeResponse(status_code=429, headers={"Retry-After": "1"})
+
+    with pytest.raises(requests.exceptions.HTTPError, match="max retry count"):
+        fetch_tracks_batch(["trk1"], http_get=http_get, token="tok", wait=lambda s: None)
+
+
+def test_fetch_tracks_batch_retries_500_then_succeeds(make):
+    responses = [
+        FakeResponse(status_code=500),
+        FakeResponse(payload={"tracks": [make.track(1)]}),
+    ]
+    tracks = fetch_tracks_batch(
+        ["trk1"], http_get=lambda url, headers=None: responses.pop(0),
+        token="tok", wait=lambda s: None,
+    )
+    assert len(tracks) == 1
+
+
+def test_fetch_tracks_batch_gives_up_after_max_500s():
+    def http_get(url, headers=None):
+        return FakeResponse(status_code=500)
+
+    with pytest.raises(requests.exceptions.HTTPError, match="max retry count"):
+        fetch_tracks_batch(["trk1"], http_get=http_get, token="tok", wait=lambda s: None)
+
+
+def test_fetch_tracks_batch_raises_on_4xx():
+    def http_get(url, headers=None):
+        return FakeResponse(status_code=403)
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        fetch_tracks_batch(["trk1"], http_get=http_get, token="tok")
+
+
+def test_missing_retry_after_header_defaults():
+    from application.mastering.backfill import DEFAULT_RETRY_AFTER_SECONDS, _retry_after_seconds
+    assert _retry_after_seconds(FakeResponse(status_code=429)) == DEFAULT_RETRY_AFTER_SECONDS
+    assert _retry_after_seconds(
+        FakeResponse(status_code=429, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"})
+    ) == DEFAULT_RETRY_AFTER_SECONDS
+
+
+def test_max_retries_matches_engine_policy():
+    # The backfill mirrors the crawl engine's bounded rate-limit policy.
+    from application import api_call_engine
+    assert MAX_429_RETRIES == api_call_engine.MAX_HTTP_429_RETRIES_PER_REQUEST
+    assert MAX_RETRY_AFTER_SECONDS == api_call_engine.MAX_RETRY_AFTER_SECONDS

--- a/tests/test_mastering_clustering.py
+++ b/tests/test_mastering_clustering.py
@@ -182,6 +182,34 @@ def test_remix_without_resolvable_parent_has_no_edge():
     assert member_of(result, "t1").kind == "remix"
 
 
+def test_remix_of_internal_hyphen_title_emits_the_edge():
+    # "Re-Wired" contains an internal hyphen: the base of the hyphenated
+    # remix marker must be the FULL title, or the parent is never resolved.
+    result = cluster_tracks([
+        rec("t1", "Re-Wired", isrc="ISRC1", duration_ms=183000),
+        rec("t2", "Re-Wired - Kasabian Remix", isrc="ISRC2", duration_ms=190000),
+    ])
+    assert len(result.clusters) == 2
+    assert member_of(result, "t2").kind == "remix"
+    assert [
+        (e.remix_song_id, e.parent_song_id) for e in result.remix_edges
+    ] == [(cluster_of(result, "t2").song_id, cluster_of(result, "t1").song_id)]
+
+
+def test_remix_of_internal_hyphen_title_resolves_the_right_parent():
+    # A truncated base ("t" instead of "t shirt") would attach the remix to
+    # the WRONG sibling Song by the same artist.
+    result = cluster_tracks([
+        rec("t1", "T", isrc="ISRC1", duration_ms=100000),
+        rec("t2", "T-Shirt", isrc="ISRC2", duration_ms=150000),
+        rec("t3", "T-Shirt - Blondish Remix", isrc="ISRC3", duration_ms=151000),
+    ])
+    assert len(result.remix_edges) == 1
+    edge = result.remix_edges[0]
+    assert edge.remix_song_id == cluster_of(result, "t3").song_id
+    assert edge.parent_song_id == cluster_of(result, "t2").song_id  # T-Shirt, not T
+
+
 def test_two_copies_of_the_same_remix_merge_together():
     result = cluster_tracks([
         rec("t1", "Song (X Remix)", isrc="ISRC1"),

--- a/tests/test_mastering_clustering.py
+++ b/tests/test_mastering_clustering.py
@@ -222,6 +222,61 @@ def test_split_override_tears_tracks_out():
     assert member_of(result, "t2").method == "manual"
 
 
+def test_split_override_on_shared_isrc_pair_yields_distinct_song_ids():
+    # The mock's deluxe pair shape (trk000052/53): the label reused the ISRC.
+    # A wrongly-reused ISRC is exactly when a human reaches for a split
+    # override, so the two resulting Songs MUST have distinct ids — otherwise
+    # the graph MERGE silently re-unites what the override tore apart.
+    records = [
+        rec("t1", "Neon Skyline", isrc="SHARED"),
+        rec("t2", "Neon Skyline - Deluxe Edition", isrc="SHARED", duration_ms=290000),
+    ]
+    result = cluster_tracks(records, overrides=Overrides(splits=[["t2"]]))
+    assert len(result.clusters) == 2
+
+    kept = cluster_of(result, "t1")
+    torn = cluster_of(result, "t2")
+    assert kept.song_id != torn.song_id
+    assert kept.song_id == "SHARED"  # the natural cluster keeps the ISRC id
+    assert torn.song_id.startswith("SHARED:split:")
+    assert torn.split_derived and not kept.split_derived
+    assert member_of(result, "t2").method == "manual"
+    # The rename is surfaced, not silent.
+    assert any("split" in w.lower() for w in result.warnings)
+
+    # Deterministic: same input in any order yields the same ids.
+    again = cluster_tracks(list(reversed(records)), overrides=Overrides(splits=[["t2"]]))
+    assert sorted(c.song_id for c in again.clusters) == \
+           sorted(c.song_id for c in result.clusters)
+
+
+def test_split_override_without_id_collision_keeps_natural_ids():
+    result = cluster_tracks(
+        [
+            rec("t1", "Same Title", isrc="ISRC1", duration_ms=200000),
+            rec("t2", "Same Title", isrc="ISRC2", duration_ms=200500),
+        ],
+        overrides=Overrides(splits=[["t2"]]),
+    )
+    # Distinct ISRCs: no collision, so both Songs keep their natural ISRC ids.
+    assert {c.song_id for c in result.clusters} == {"ISRC1", "ISRC2"}
+    assert cluster_of(result, "t2").split_derived
+
+
+def test_two_shared_isrc_splits_get_distinct_ids():
+    result = cluster_tracks(
+        [
+            rec("t1", "Triplet", isrc="SHARED"),
+            rec("t2", "Triplet", isrc="SHARED"),
+            rec("t3", "Triplet", isrc="SHARED"),
+        ],
+        overrides=Overrides(splits=[["t2"], ["t3"]]),
+    )
+    ids = [c.song_id for c in result.clusters]
+    assert len(ids) == 3
+    assert len(set(ids)) == 3
+
+
 def test_override_with_unknown_ids_warns_and_continues():
     result = cluster_tracks(
         [rec("t1", "A Song", isrc="ISRC1")],

--- a/tests/test_mastering_clustering.py
+++ b/tests/test_mastering_clustering.py
@@ -1,0 +1,343 @@
+"""Unit tests for the pure clustering core (plan 03 T5/T7): the identity
+ladder on plain dicts — no Neo4j, no mock service, fully offline."""
+import pytest
+
+from application.mastering.cluster import (
+    DURATION_TOLERANCE_MS,
+    cluster_tracks,
+    compute_song_id,
+    track_record_from_api,
+)
+from application.mastering.overrides import Overrides
+
+
+def rec(tid, name, isrc=None, linked_from_id=None, duration_ms=200000,
+        explicit=False, artist="artA", artist_name="Artist A"):
+    return {
+        "id": tid,
+        "name": name,
+        "isrc": isrc,
+        "linked_from_id": linked_from_id,
+        "duration_ms": duration_ms,
+        "explicit": explicit,
+        "artist_ids": [artist],
+        "artist_names": [artist_name],
+    }
+
+
+def cluster_of(result, track_id):
+    for c in result.clusters:
+        if any(m.track_id == track_id for m in c.members):
+            return c
+    raise AssertionError(f"No cluster contains {track_id}")
+
+
+def member_of(result, track_id):
+    for c in result.clusters:
+        for m in c.members:
+            if m.track_id == track_id:
+                return m
+    raise AssertionError(f"No member for {track_id}")
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: ISRC
+# ---------------------------------------------------------------------------
+
+def test_same_isrc_merges_regardless_of_title_and_duration():
+    # The deluxe re-release case: label reused the ISRC. Same recording, done.
+    result = cluster_tracks([
+        rec("t1", "Neon Skyline", isrc="USMCK2600052"),
+        rec("t2", "Neon Skyline - Deluxe Edition", isrc="USMCK2600052", duration_ms=290000),
+    ])
+    c = cluster_of(result, "t1")
+    assert {m.track_id for m in c.members} == {"t1", "t2"}
+    assert c.song_id == "USMCK2600052"  # exactly one distinct ISRC -> the ISRC
+    assert all(m.method == "isrc" and m.confidence == 1.0 for m in c.members)
+
+
+def test_different_isrcs_do_not_merge_on_isrc_alone():
+    result = cluster_tracks([
+        rec("t1", "Completely Different", isrc="ISRC1"),
+        rec("t2", "Another Thing Entirely", isrc="ISRC2"),
+    ])
+    assert len(result.clusters) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: linked_from
+# ---------------------------------------------------------------------------
+
+def test_linked_from_unions_the_two_ids():
+    result = cluster_tracks([
+        rec("t1", "Some Song", isrc="ISRC1"),
+        rec("t2", "Some Song", isrc="ISRC2", linked_from_id="t1", duration_ms=290000),
+    ])
+    c = cluster_of(result, "t1")
+    assert {m.track_id for m in c.members} == {"t1", "t2"}
+    assert member_of(result, "t2").method == "linked_from"
+    # Two distinct ISRCs -> deterministic hash id, never a bare Spotify id.
+    assert c.song_id.startswith("song:")
+
+
+def test_linked_from_to_unknown_track_is_ignored_with_warning():
+    result = cluster_tracks([rec("t1", "Some Song", linked_from_id="ghost")])
+    assert len(result.clusters) == 1
+    assert any("ghost" in w for w in result.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Tier 3: heuristics (normalized title + primary artist + duration gate)
+# ---------------------------------------------------------------------------
+
+def test_clean_explicit_twins_merge_and_get_kinds():
+    result = cluster_tracks([
+        rec("t1", "Gutter Anthem", isrc="ISRC1", explicit=True, duration_ms=201000),
+        rec("t2", "Gutter Anthem", isrc="ISRC2", explicit=False, duration_ms=200000),
+    ])
+    c = cluster_of(result, "t1")
+    assert {m.track_id for m in c.members} == {"t1", "t2"}
+    assert member_of(result, "t1").kind == "explicit"
+    assert member_of(result, "t2").kind == "clean"
+    assert all(m.method == "heuristic" for m in c.members)
+    assert c.heuristic_only
+
+
+def test_remaster_suffix_merges_with_original():
+    result = cluster_tracks([
+        rec("t1", "Cathedral Bells - 2011 Remaster", isrc="ISRC1", duration_ms=184000),
+        rec("t2", "Cathedral Bells", isrc="ISRC2", duration_ms=183000),
+    ])
+    c = cluster_of(result, "t1")
+    assert {m.track_id for m in c.members} == {"t1", "t2"}
+    assert member_of(result, "t1").kind == "remaster"
+    assert member_of(result, "t2").kind == "canonical"
+
+
+def test_duration_gate_blocks_same_titled_different_songs():
+    # "Untitled" intro vs "Untitled" closer: same name, wildly different length.
+    result = cluster_tracks([
+        rec("t1", "Untitled", isrc="ISRC1", duration_ms=45000),
+        rec("t2", "Untitled", isrc="ISRC2", duration_ms=45000 + DURATION_TOLERANCE_MS + 1),
+    ])
+    assert len(result.clusters) == 2
+
+
+def test_unknown_duration_does_not_merge():
+    result = cluster_tracks([
+        rec("t1", "Some Song", isrc="ISRC1", duration_ms=None),
+        rec("t2", "Some Song", isrc="ISRC2", duration_ms=200000),
+    ])
+    assert len(result.clusters) == 2
+
+
+def test_different_primary_artist_blocks_heuristic_merge():
+    result = cluster_tracks([
+        rec("t1", "Some Song", isrc="ISRC1", artist="artA"),
+        rec("t2", "Some Song", isrc="ISRC2", artist="artB"),
+    ])
+    assert len(result.clusters) == 2
+
+
+def test_feat_credit_redundant_with_artists_still_merges():
+    result = cluster_tracks([
+        rec("t1", "Umbrella (feat. Jay-Z)", isrc="ISRC1"),
+        rec("t2", "Umbrella", isrc="ISRC2"),
+    ])
+    # Both records credit only "Artist A", so the feat clause is signal -> kept.
+    assert len(result.clusters) == 2
+
+    records = [
+        rec("t1", "Umbrella (feat. Jay-Z)", isrc="ISRC1"),
+        rec("t2", "Umbrella", isrc="ISRC2"),
+    ]
+    records[0]["artist_ids"] = ["artA", "artJ"]
+    records[0]["artist_names"] = ["Artist A", "Jay-Z"]
+    result = cluster_tracks(records)
+    assert {m.track_id for m in cluster_of(result, "t1").members} == {"t1", "t2"}
+
+
+# ---------------------------------------------------------------------------
+# Remixes: never merged with the parent, but REMIX_OF when resolvable
+# ---------------------------------------------------------------------------
+
+def test_remix_does_not_merge_with_parent_but_gets_remix_of_edge():
+    result = cluster_tracks([
+        rec("t1", "Cathedral Bells", isrc="ISRC1", duration_ms=183000),
+        rec("t2", "Cathedral Bells (Nightcrawler Remix)", isrc="ISRC2", duration_ms=184500),
+    ])
+    assert len(result.clusters) == 2  # duration was tempting; title identity wins
+    remix_cluster = cluster_of(result, "t2")
+    parent_cluster = cluster_of(result, "t1")
+    assert member_of(result, "t2").kind == "remix"
+    assert result.remix_edges and result.remix_edges[0].remix_song_id == remix_cluster.song_id
+    assert result.remix_edges[0].parent_song_id == parent_cluster.song_id
+
+
+def test_remix_without_resolvable_parent_has_no_edge():
+    result = cluster_tracks([
+        rec("t1", "Orphan Groove (Somebody Remix)", isrc="ISRC1"),
+    ])
+    assert result.remix_edges == []
+    assert member_of(result, "t1").kind == "remix"
+
+
+def test_two_copies_of_the_same_remix_merge_together():
+    result = cluster_tracks([
+        rec("t1", "Song (X Remix)", isrc="ISRC1"),
+        rec("t2", "Song (X Remix)", isrc="ISRC2"),
+        rec("t3", "Song", isrc="ISRC3"),
+    ])
+    assert {m.track_id for m in cluster_of(result, "t1").members} == {"t1", "t2"}
+    assert len(result.remix_edges) == 1  # deduped, one edge to the parent
+
+
+# ---------------------------------------------------------------------------
+# Tier 4: manual overrides win
+# ---------------------------------------------------------------------------
+
+def test_merge_override_forces_a_cluster():
+    result = cluster_tracks(
+        [
+            rec("t1", "Totally Different A", isrc="ISRC1"),
+            rec("t2", "Totally Different B", isrc="ISRC2"),
+        ],
+        overrides=Overrides(merges=[["t1", "t2"]]),
+    )
+    c = cluster_of(result, "t1")
+    assert {m.track_id for m in c.members} == {"t1", "t2"}
+    assert all(m.method == "manual" and m.confidence == 1.0 for m in c.members)
+
+
+def test_split_override_tears_tracks_out():
+    # Heuristics would merge these twins; the override says they're different.
+    result = cluster_tracks(
+        [
+            rec("t1", "Same Title", isrc="ISRC1", duration_ms=200000),
+            rec("t2", "Same Title", isrc="ISRC2", duration_ms=200500),
+        ],
+        overrides=Overrides(splits=[["t2"]]),
+    )
+    assert len(result.clusters) == 2
+    assert member_of(result, "t2").method == "manual"
+
+
+def test_override_with_unknown_ids_warns_and_continues():
+    result = cluster_tracks(
+        [rec("t1", "A Song", isrc="ISRC1")],
+        overrides=Overrides(merges=[["t1", "missing"]], splits=[["also-missing"]]),
+    )
+    assert len(result.clusters) == 1
+    assert sum("ignored" in w for w in result.warnings) == 2
+
+
+# ---------------------------------------------------------------------------
+# Song identity, determinism, shapes
+# ---------------------------------------------------------------------------
+
+def test_singleton_with_isrc_uses_the_isrc_as_song_id():
+    result = cluster_tracks([rec("t1", "Loner", isrc="USXYZ1234567")])
+    c = result.clusters[0]
+    assert c.song_id == "USXYZ1234567"
+    assert c.members[0].method == "isrc"
+    assert c.members[0].kind == "canonical"
+    assert c.members[0].confidence == 1.0
+
+
+def test_singleton_without_isrc_hashes_never_a_bare_spotify_id():
+    result = cluster_tracks([rec("t1", "Loner", isrc=None)])
+    assert result.clusters[0].song_id.startswith("song:")
+    assert "t1" not in result.clusters[0].song_id
+
+
+def test_song_id_is_stable_under_member_order():
+    members_a = cluster_tracks([
+        rec("t1", "Twin", isrc="ISRC1"),
+        rec("t2", "Twin", isrc="ISRC2"),
+    ]).clusters[0].song_id
+    members_b = cluster_tracks([
+        rec("t2", "Twin", isrc="ISRC2"),
+        rec("t1", "Twin", isrc="ISRC1"),
+    ]).clusters[0].song_id
+    assert members_a == members_b
+
+
+def test_compute_song_id_rules():
+    from application.mastering.cluster import Member
+
+    def m(tid, isrc):
+        return Member(track_id=tid, kind="canonical", method="heuristic",
+                      confidence=0.85, isrc=isrc)
+
+    # Exactly one DISTINCT ISRC -> the ISRC, even when a member lacks one
+    # (the cluster's recording identity is known; a later backfill that
+    # confirms the same ISRC keeps the Song id stable).
+    assert compute_song_id([m("t1", "ISRC1"), m("t2", None)]) == "ISRC1"
+    # Two distinct ISRCs -> deterministic hash over ISRCs + isrc-less ids.
+    hashed = compute_song_id([m("t1", "ISRC1"), m("t2", "ISRC2"), m("t3", None)])
+    assert hashed.startswith("song:")
+    assert hashed == compute_song_id([m("t3", None), m("t2", "ISRC2"), m("t1", "ISRC1")])
+
+
+def test_every_track_lands_in_exactly_one_cluster():
+    records = [
+        rec("t1", "Gutter Anthem", isrc="I1", explicit=True, duration_ms=201000),
+        rec("t2", "Gutter Anthem", isrc="I2", explicit=False),
+        rec("t3", "Unrelated", isrc="I3"),
+        rec("t4", "Cathedral Bells (Nightcrawler Remix)", isrc="I4"),
+    ]
+    result = cluster_tracks(records)
+    seen = [m.track_id for c in result.clusters for m in c.members]
+    assert sorted(seen) == ["t1", "t2", "t3", "t4"]
+
+
+def test_result_is_deterministic_and_idempotent():
+    records = [
+        rec("t1", "Gutter Anthem", isrc="I1", explicit=True, duration_ms=201000),
+        rec("t2", "Gutter Anthem", isrc="I2", explicit=False),
+        rec("t3", "Neon Skyline", isrc="SHARED"),
+        rec("t4", "Neon Skyline - Deluxe Edition", isrc="SHARED"),
+    ]
+    a = cluster_tracks(records)
+    b = cluster_tracks(list(reversed(records)))
+    assert [c.song_id for c in a.clusters] == [c.song_id for c in b.clusters]
+    assert [[m.track_id for m in c.members] for c in a.clusters] == \
+           [[m.track_id for m in c.members] for c in b.clusters]
+
+
+def test_title_prefers_least_decorated_name():
+    result = cluster_tracks([
+        rec("t1", "Neon Skyline - Deluxe Edition", isrc="SHARED"),
+        rec("t2", "Neon Skyline", isrc="SHARED"),
+    ])
+    assert result.clusters[0].title == "Neon Skyline"
+
+
+def test_duration_spread_reported():
+    result = cluster_tracks([
+        rec("t1", "Twin", isrc="SHARED", duration_ms=200000),
+        rec("t2", "Twin", isrc="SHARED", duration_ms=202500),
+    ])
+    assert result.clusters[0].duration_spread_ms == 2500
+
+
+# ---------------------------------------------------------------------------
+# API-shape conversion
+# ---------------------------------------------------------------------------
+
+def test_track_record_from_api(make):
+    track = make.track(1, isrc="USTST0000001", linked_from_id="trk0")
+    record = track_record_from_api(track)
+    assert record["id"] == "trk1"
+    assert record["isrc"] == "USTST0000001"
+    assert record["linked_from_id"] == "trk0"
+    assert record["duration_ms"] == 200000
+    assert record["artist_ids"] == ["art1"]
+    assert record["artist_names"] == ["Artist 1"]
+
+
+def test_track_record_from_api_tolerates_missing_fields(make):
+    track = make.track(2, isrc="")  # no external_ids at all
+    record = track_record_from_api(track)
+    assert record["isrc"] is None
+    assert record["linked_from_id"] is None

--- a/tests/test_mastering_e2e.py
+++ b/tests/test_mastering_e2e.py
@@ -1,0 +1,331 @@
+"""E2E-ish tests for entity mastering (plan 03 T7).
+
+Three layers, each degrading gracefully:
+  - mock-service tests fetch the crafted variant twins over HTTP (skip when
+    the spotify_mock compose service isn't reachable) and feed them to the
+    pure clustering logic;
+  - direct catalog checks import mock_spotify.catalog when it's importable
+    (host runs; the tests container doesn't mount mock_spotify/, so they skip
+    there — the HTTP tests cover the same ground in compose);
+  - graph-write tests run behind the neo4j_driver skip fixture.
+"""
+import pytest
+import requests
+
+from application.mastering.cluster import cluster_tracks, track_record_from_api
+from application.mastering.overrides import Overrides
+from application.mastering.run import write_mastering_result
+
+# Mirrors mock_spotify/catalog.py VARIANTS (kept literal on purpose: the tests
+# container doesn't mount mock_spotify/, and drift would fail loudly below).
+DELUXE_PAIR_IDS = ("trk000052", "trk000053")
+CLEAN_EXPLICIT_TWIN_IDS = ("trk000054", "trk000055")
+REMASTER_PAIR_IDS = ("trk000056", "trk000057")
+REMIX_TRACK_ID = "trk000058"
+ALL_VARIANT_IDS = (
+    *DELUXE_PAIR_IDS, *CLEAN_EXPLICIT_TWIN_IDS, *REMASTER_PAIR_IDS, REMIX_TRACK_ID,
+)
+
+
+def _fetch_tracks(mock_base, ids):
+    tracks = requests.get(f"{mock_base}/v1/tracks?ids={','.join(ids)}").json()["tracks"]
+    assert all(tracks), f"every variant id must resolve in the mock catalog: {ids}"
+    return tracks
+
+
+def _cluster_containing(result, track_id):
+    for cluster in result.clusters:
+        if any(m.track_id == track_id for m in cluster.members):
+            return cluster
+    raise AssertionError(f"No cluster contains {track_id}")
+
+
+# ---------------------------------------------------------------------------
+# Mock catalog over HTTP (the shape the crawler actually sees)
+# ---------------------------------------------------------------------------
+
+def test_catalog_emits_deterministic_isrcs(mock_base):
+    first = _fetch_tracks(mock_base, ("trk000000", "trk000001"))
+    second = _fetch_tracks(mock_base, ("trk000000", "trk000001"))
+    for a, b in zip(first, second):
+        assert a["external_ids"]["isrc"] == b["external_ids"]["isrc"]
+    assert first[0]["external_ids"]["isrc"] != first[1]["external_ids"]["isrc"]
+
+
+def test_liked_songs_pages_carry_isrcs(mock_base):
+    page = requests.get(f"{mock_base}/v1/me/tracks?offset=52&limit=7").json()
+    for item in page["items"]:
+        assert item["track"]["external_ids"]["isrc"]
+
+
+def test_deluxe_pair_shares_one_isrc(mock_base):
+    a, b = _fetch_tracks(mock_base, DELUXE_PAIR_IDS)
+    assert a["external_ids"]["isrc"] == b["external_ids"]["isrc"]
+    assert a["id"] != b["id"]
+
+
+def test_clean_explicit_twins_differ_in_isrc_not_title(mock_base):
+    a, b = _fetch_tracks(mock_base, CLEAN_EXPLICIT_TWIN_IDS)
+    assert a["external_ids"]["isrc"] != b["external_ids"]["isrc"]
+    assert a["name"] == b["name"]
+    assert a["explicit"] != b["explicit"]
+    assert a["artists"][0]["id"] == b["artists"][0]["id"]
+    assert abs(a["duration_ms"] - b["duration_ms"]) <= 3000
+
+
+def test_mock_twins_flow_through_the_identity_ladder(mock_base):
+    """The T7 deliverable: crafted variants -> track records -> clusters."""
+    tracks = _fetch_tracks(mock_base, ALL_VARIANT_IDS)
+    records = [track_record_from_api(t) for t in tracks]
+    result = cluster_tracks(records)
+
+    # (a) deluxe re-release pair: ISRC tier, Song id IS the shared ISRC
+    deluxe = _cluster_containing(result, DELUXE_PAIR_IDS[0])
+    assert {m.track_id for m in deluxe.members} == set(DELUXE_PAIR_IDS)
+    assert deluxe.song_id == "USMCK2600052"
+    assert all(m.method == "isrc" and m.confidence == 1.0 for m in deluxe.members)
+
+    # (b) clean/explicit twins: heuristic tier, kinds assigned from the flag
+    twins = _cluster_containing(result, CLEAN_EXPLICIT_TWIN_IDS[0])
+    assert {m.track_id for m in twins.members} == set(CLEAN_EXPLICIT_TWIN_IDS)
+    assert {m.kind for m in twins.members} == {"explicit", "clean"}
+    assert all(m.method == "heuristic" for m in twins.members)
+    assert twins.song_id.startswith("song:")  # two ISRCs -> hash, never a Spotify id
+
+    # (c) remaster folds into the original; the strip is recorded as the kind
+    remaster = _cluster_containing(result, REMASTER_PAIR_IDS[0])
+    assert {m.track_id for m in remaster.members} == set(REMASTER_PAIR_IDS)
+    kinds = {m.track_id: m.kind for m in remaster.members}
+    assert kinds[REMASTER_PAIR_IDS[0]] == "remaster"
+    assert kinds[REMASTER_PAIR_IDS[1]] == "canonical"
+
+    # (d) the remix stands alone... and points at its parent Song
+    remix = _cluster_containing(result, REMIX_TRACK_ID)
+    assert {m.track_id for m in remix.members} == {REMIX_TRACK_ID}
+    assert remix.members[0].kind == "remix"
+    assert [
+        (e.remix_song_id, e.parent_song_id) for e in result.remix_edges
+    ] == [(remix.song_id, remaster.song_id)]
+
+    # every variant landed in exactly one cluster
+    assigned = sorted(m.track_id for c in result.clusters for m in c.members)
+    assert assigned == sorted(ALL_VARIANT_IDS)
+
+
+# ---------------------------------------------------------------------------
+# Direct catalog checks (host runs only — skips where mock_spotify isn't
+# importable; the HTTP tests above cover compose)
+# ---------------------------------------------------------------------------
+
+def test_catalog_module_variants_match_this_files_ids():
+    catalog = pytest.importorskip("mock_spotify.catalog")
+    assert catalog.DELUXE_PAIR_IDS == DELUXE_PAIR_IDS
+    assert catalog.CLEAN_EXPLICIT_TWIN_IDS == CLEAN_EXPLICIT_TWIN_IDS
+    assert catalog.REMASTER_PAIR_IDS == REMASTER_PAIR_IDS
+    assert catalog.REMIX_TRACK_ID == REMIX_TRACK_ID
+    # Variants live inside the default catalog so liked-songs crawls reach them.
+    assert max(catalog.VARIANTS) < catalog.N_TRACKS
+
+
+def test_catalog_module_twins_cluster_without_http():
+    catalog = pytest.importorskip("mock_spotify.catalog")
+    records = [
+        track_record_from_api(catalog.get_by_id("tracks", tid))
+        for tid in ALL_VARIANT_IDS
+    ]
+    result = cluster_tracks(records)
+    assert _cluster_containing(result, DELUXE_PAIR_IDS[0]).song_id == "USMCK2600052"
+    assert len(result.remix_edges) == 1
+
+
+# ---------------------------------------------------------------------------
+# Neo4j write layer (skips when Neo4j isn't reachable)
+# ---------------------------------------------------------------------------
+
+MARKER = "MSTTEST"
+
+
+@pytest.fixture
+def graph(neo4j_driver):
+    """Purge this module's distinctively-marked nodes before and after."""
+    def purge():
+        neo4j_driver.execute_query(
+            f"MATCH (n) WHERE n.uri CONTAINS '{MARKER}' DETACH DELETE n")
+        neo4j_driver.execute_query(
+            f"MATCH (s:Song) WHERE s.id CONTAINS '{MARKER}' DETACH DELETE s")
+    purge()
+    yield neo4j_driver
+    purge()
+
+
+def _delete_songs(driver, result):
+    ids = [c.song_id for c in result.clusters]
+    driver.execute_query("MATCH (s:Song) WHERE s.id IN $ids DETACH DELETE s", ids=ids)
+
+
+def _seed_graph_tracks(driver, tracks):
+    """Seed Track/Artist nodes directly (mastering-layer tests exercise the
+    mastering Cyphers, not the crawl insert path — that's covered above)."""
+    records = [track_record_from_api(t) | {"uri": t["uri"]} for t in tracks]
+    driver.execute_query(
+        "UNWIND $records AS record "
+        "MERGE (t:Track {uri: record.uri}) "
+        "SET t.id = record.id, t.name = record.name, t.isrc = record.isrc, "
+        "    t.linked_from_id = record.linked_from_id, "
+        "    t.duration_ms = record.duration_ms, t.explicit = record.explicit, "
+        "    t.is_local = false "
+        "WITH record, t UNWIND range(0, size(record.artist_ids) - 1) AS idx "
+        "MERGE (ar:Artist {uri: 'spotify:artist:' + record.artist_ids[idx] + 'MSTTEST'}) "
+        "SET ar.id = record.artist_ids[idx], ar.name = record.artist_names[idx] "
+        "MERGE (t)<-[:CREATED]-(ar)",
+        records=records,
+    )
+
+
+def test_track_insert_persists_and_refreshes_enrichment_fields(graph, make):
+    from application.response_handlers.tracks.several_tracks import GetSeveralTracksResponseHandler
+
+    def stored():
+        recs, _, _ = graph.execute_query(
+            "MATCH (t:Track {id: 'trkMSTTEST1'}) "
+            "RETURN t.isrc AS isrc, t.album_type AS album_type, t.linked_from_id AS lnk, "
+            "t.artist_ids AS artist_ids")
+        return recs[0]["isrc"], recs[0]["album_type"], recs[0]["lnk"], recs[0]["artist_ids"]
+
+    track = make.track("MSTTEST1", isrc=f"{MARKER}ISRC1", linked_from_id=f"{MARKER}LNK1")
+    GetSeveralTracksResponseHandler(None, 0, {"tracks": [track]}).write_to_neo4j(driver=graph)
+    assert stored() == (f"{MARKER}ISRC1", "album", f"{MARKER}LNK1", ["artMSTTEST1"])
+
+    # A payload WITHOUT the enrichment fields must not erase them (coalesce).
+    bare = make.track("MSTTEST1", isrc="")
+    bare["album"]["album_type"] = None
+    GetSeveralTracksResponseHandler(None, 0, {"tracks": [bare]}).write_to_neo4j(driver=graph)
+    assert stored() == (f"{MARKER}ISRC1", "album", f"{MARKER}LNK1", ["artMSTTEST1"])
+
+    # A payload WITH a fresh isrc refreshes it (the backfill path: ON MATCH SET).
+    refreshed = make.track("MSTTEST1", isrc=f"{MARKER}ISRC1B")
+    GetSeveralTracksResponseHandler(None, 0, {"tracks": [refreshed]}).write_to_neo4j(driver=graph)
+    assert stored()[0] == f"{MARKER}ISRC1B"
+
+
+def test_liked_songs_insert_persists_enrichment_fields(graph, make):
+    from application.response_handlers.me.my_liked_songs import LikedSongsPlaylistResponseHandler
+
+    def stored():
+        recs, _, _ = graph.execute_query(
+            "MATCH (t:Track {id: 'trkMSTTEST2'}) RETURN t.isrc AS isrc, t.album_type AS album_type")
+        return recs[0]["isrc"], recs[0]["album_type"]
+
+    track = make.track("MSTTEST2", isrc=f"{MARKER}ISRC2")
+    LikedSongsPlaylistResponseHandler(None, 0, make.liked_page([track])).write_to_neo4j(driver=graph)
+    assert stored() == (f"{MARKER}ISRC2", "album")
+
+    # ON MATCH: a payload without external_ids must not erase the isrc...
+    bare = make.track("MSTTEST2", isrc="")
+    LikedSongsPlaylistResponseHandler(None, 0, make.liked_page([bare])).write_to_neo4j(driver=graph)
+    assert stored() == (f"{MARKER}ISRC2", "album")
+
+    # ...while a payload with a fresh one refreshes it (the backfill path).
+    refreshed = make.track("MSTTEST2", isrc=f"{MARKER}ISRC2B")
+    LikedSongsPlaylistResponseHandler(None, 0, make.liked_page([refreshed])).write_to_neo4j(driver=graph)
+    assert stored()[0] == f"{MARKER}ISRC2B"
+
+
+def test_fetch_query_prefers_stored_artist_ids_with_edge_fallback(graph, make):
+    from application.mastering.run import fetch_track_records
+
+    artists = [make.artist("MSTTESTzz"), make.artist("MSTTESTaa")]
+    track = make.track("MSTTEST3", artists=artists, isrc=f"{MARKER}ISRC3")
+    _seed_graph_tracks(graph, [track])
+
+    def fetch_one():
+        records = [r for r in fetch_track_records(graph) if r["id"] == "trkMSTTEST3"]
+        assert len(records) == 1
+        return records[0]
+
+    # Legacy node (no t.artist_ids): sorted CREATED-edge ids as the fallback.
+    record = fetch_one()
+    assert record["isrc"] == f"{MARKER}ISRC3"
+    assert record["artist_ids"] == ["artMSTTESTaa", "artMSTTESTzz"]  # sorted
+
+    # Once the insert/backfill stored the credit-ordered list, it wins.
+    graph.execute_query(
+        "MATCH (t:Track {id: 'trkMSTTEST3'}) SET t.artist_ids = $ids",
+        ids=["artMSTTESTzz", "artMSTTESTaa"])
+    assert fetch_one()["artist_ids"] == ["artMSTTESTzz", "artMSTTESTaa"]
+
+
+def test_write_mastering_result_is_idempotent_and_repoints(graph, make):
+    artist = make.artist("MSTTEST4")
+    tracks = [
+        make.track("MSTTEST4a", artists=[artist], isrc=f"{MARKER}ISRC4A"),
+        make.track("MSTTEST4b", artists=[artist], isrc=f"{MARKER}ISRC4B"),
+    ]
+    tracks[0]["name"] = tracks[1]["name"] = "Gutter Anthem MSTTEST"
+    tracks[0]["explicit"] = True
+    _seed_graph_tracks(graph, tracks)
+
+    records = [track_record_from_api(t) for t in tracks]
+    merged = cluster_tracks(records)
+    split = cluster_tracks(records, overrides=Overrides(splits=[["trkMSTTEST4b"]]))
+    try:
+        write_mastering_result(merged, graph)
+        write_mastering_result(merged, graph)  # idempotent re-run
+
+        recs, _, _ = graph.execute_query(
+            "MATCH (t:Track)-[v:VERSION_OF]->(s:Song) WHERE t.id STARTS WITH 'trkMSTTEST4' "
+            "RETURN t.id AS tid, s.id AS sid, v.kind AS kind, v.method AS method, "
+            "v.confidence AS confidence ORDER BY tid")
+        assert len(recs) == 2  # exactly ONE VERSION_OF each, even after a re-run
+        assert recs[0]["sid"] == recs[1]["sid"]
+        assert {r["kind"] for r in recs} == {"explicit", "clean"}
+        assert all(r["method"] == "heuristic" and r["confidence"] == 0.85 for r in recs)
+
+        # An override lands: the next run RE-POINTS the edges (no accumulation,
+        # and the now-empty Song is left alone — never deleted).
+        write_mastering_result(split, graph)
+        recs, _, _ = graph.execute_query(
+            "MATCH (t:Track)-[v:VERSION_OF]->(s:Song) WHERE t.id STARTS WITH 'trkMSTTEST4' "
+            "RETURN t.id AS tid, s.id AS sid ORDER BY tid")
+        assert len(recs) == 2
+        assert recs[0]["sid"] != recs[1]["sid"]
+
+        old_song = [c.song_id for c in merged.clusters]
+        recs, _, _ = graph.execute_query(
+            "MATCH (s:Song) WHERE s.id IN $ids RETURN count(s) AS c", ids=old_song)
+        assert recs[0]["c"] == len(old_song)  # orphaned, not deleted
+    finally:
+        _delete_songs(graph, merged)
+        _delete_songs(graph, split)
+
+
+def test_remix_of_edge_written(graph, make):
+    artist = make.artist("MSTTEST5")
+    parent = make.track("MSTTEST5a", artists=[artist], isrc=f"{MARKER}ISRC5A")
+    remix = make.track("MSTTEST5b", artists=[artist], isrc=f"{MARKER}ISRC5B")
+    parent["name"] = "Cathedral MSTTEST"
+    remix["name"] = "Cathedral MSTTEST (Nightcrawler Remix)"
+    _seed_graph_tracks(graph, [parent, remix])
+
+    result = cluster_tracks([track_record_from_api(t) for t in (parent, remix)])
+    assert result.remix_edges
+    try:
+        write_mastering_result(result, graph)
+        recs, _, _ = graph.execute_query(
+            "MATCH (remix:Song)-[r:REMIX_OF]->(parent:Song) "
+            "WHERE remix.id = $rid AND parent.id = $pid RETURN r.confidence AS confidence",
+            rid=result.remix_edges[0].remix_song_id,
+            pid=result.remix_edges[0].parent_song_id)
+        assert recs and recs[0]["confidence"] == 0.9
+    finally:
+        _delete_songs(graph, result)
+
+
+def test_song_uniqueness_constraint_applies(neo4j_driver):
+    from application.graph_database.initialize_database_environment import (
+        apply_uniqueness_constraints,
+    )
+    apply_uniqueness_constraints(neo4j_driver)
+    recs, _, _ = neo4j_driver.execute_query(
+        "SHOW CONSTRAINTS YIELD name WHERE name = 'song_id_uniqueness' RETURN name")
+    assert recs

--- a/tests/test_mastering_e2e.py
+++ b/tests/test_mastering_e2e.py
@@ -366,6 +366,52 @@ def test_remix_of_edge_written(graph, make):
         _delete_songs(graph, result)
 
 
+def test_remix_of_edge_repoints_when_parent_cluster_id_changes(graph, make):
+    """REMIX_OF mirrors VERSION_OF's re-pointing semantics: when a later crawl
+    flips the parent cluster's Song id (bare ISRC -> song:<hash>), a re-run
+    must RE-POINT the remix's edge, not accumulate a stale one — run.py is
+    documented idempotent/re-runnable."""
+    artist = make.artist("MSTTEST6")
+    parent_a = make.track("MSTTEST6a", artists=[artist], isrc=f"{MARKER}ISRC6A")
+    remix = make.track("MSTTEST6r", artists=[artist], isrc=f"{MARKER}ISRC6R")
+    parent_a["name"] = "Bells MSTTEST"
+    remix["name"] = "Bells MSTTEST (Nightcrawler Remix)"
+    _seed_graph_tracks(graph, [parent_a, remix])
+
+    run1 = cluster_tracks([track_record_from_api(t) for t in (parent_a, remix)])
+    assert len(run1.remix_edges) == 1
+
+    # Run 2: a second parent variant with a different ISRC joins the parent
+    # cluster (heuristic tier), so the parent Song id flips from the bare
+    # ISRC to a song:<hash> while the remix's own Song id stays stable.
+    parent_b = make.track("MSTTEST6b", artists=[artist], isrc=f"{MARKER}ISRC6B")
+    parent_b["name"] = "Bells MSTTEST"
+    parent_b["explicit"] = True
+    _seed_graph_tracks(graph, [parent_b])
+    run2 = cluster_tracks([track_record_from_api(t) for t in (parent_a, parent_b, remix)])
+    assert len(run2.remix_edges) == 1
+    assert run2.remix_edges[0].remix_song_id == run1.remix_edges[0].remix_song_id
+    assert run2.remix_edges[0].parent_song_id != run1.remix_edges[0].parent_song_id
+
+    try:
+        write_mastering_result(run1, graph)
+        write_mastering_result(run2, graph)
+        recs, _, _ = graph.execute_query(
+            "MATCH (remix:Song {id: $rid})-[:REMIX_OF]->(parent:Song) "
+            "RETURN parent.id AS pid ORDER BY pid",
+            rid=run2.remix_edges[0].remix_song_id)
+        # Re-pointed, not accumulated: exactly ONE parent — the new one. The
+        # old parent Song node itself stays (orphaned, never deleted).
+        assert [r["pid"] for r in recs] == [run2.remix_edges[0].parent_song_id]
+        recs, _, _ = graph.execute_query(
+            "MATCH (s:Song {id: $old}) RETURN count(s) AS c",
+            old=run1.remix_edges[0].parent_song_id)
+        assert recs[0]["c"] == 1
+    finally:
+        _delete_songs(graph, run1)
+        _delete_songs(graph, run2)
+
+
 def test_song_uniqueness_constraint_applies(neo4j_driver):
     from application.graph_database.initialize_database_environment import (
         apply_uniqueness_constraints,

--- a/tests/test_mastering_e2e.py
+++ b/tests/test_mastering_e2e.py
@@ -139,6 +139,51 @@ def test_catalog_module_twins_cluster_without_http():
 
 
 # ---------------------------------------------------------------------------
+# Write-layer guards (pure — no Neo4j needed)
+# ---------------------------------------------------------------------------
+
+def _plain_rec(tid, name, isrc):
+    return {
+        "id": tid, "name": name, "isrc": isrc, "linked_from_id": None,
+        "duration_ms": 200000, "explicit": False,
+        "artist_ids": ["artA"], "artist_names": ["Artist A"],
+    }
+
+
+def test_write_mastering_result_hard_fails_on_duplicate_song_ids():
+    """Belt and suspenders for the shared-ISRC split: two clusters with one
+    song_id would MERGE onto the same (:Song), silently undoing the split —
+    refuse the whole payload BEFORE any graph I/O (driver=None proves the
+    check fires first)."""
+    from dataclasses import replace
+
+    result = cluster_tracks([
+        _plain_rec("t1", "Completely Different", "ISRCX1"),
+        _plain_rec("t2", "Another Thing Entirely", "ISRCX2"),
+    ])
+    assert len(result.clusters) == 2
+    # Forge the duplicate (cluster_tracks itself must never produce one).
+    result.clusters[1] = replace(result.clusters[1], song_id=result.clusters[0].song_id)
+
+    with pytest.raises(ValueError, match="[Dd]uplicate"):
+        write_mastering_result(result, driver=None)
+
+
+def test_shared_isrc_split_survives_the_write_payload():
+    """The trk000052/53 shape: shared ISRC, user splits the pair. The payload
+    must carry two DISTINCT song ids so the graph cannot re-unite them."""
+    result = cluster_tracks(
+        [
+            _plain_rec("t1", "Neon Skyline", "USMCK2600052"),
+            _plain_rec("t2", "Neon Skyline - Deluxe Edition", "USMCK2600052"),
+        ],
+        overrides=Overrides(splits=[["t2"]]),
+    )
+    ids = [c.song_id for c in result.clusters]
+    assert len(ids) == 2 and len(set(ids)) == 2
+
+
+# ---------------------------------------------------------------------------
 # Neo4j write layer (skips when Neo4j isn't reachable)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_mastering_normalize.py
+++ b/tests/test_mastering_normalize.py
@@ -122,6 +122,29 @@ def test_hyphenated_remix_marker():
     assert result.kind == "remix"
 
 
+def test_hyphenated_remix_keeps_internal_hyphen_base_intact():
+    # The separator is the LAST " - "; the hyphen inside "Re-Wired" is part
+    # of the base title, not a marker boundary.
+    result = normalize("Re-Wired - Kasabian Remix")
+    assert result.base_text == "re wired"
+    assert result.remix_credit == "kasabian"
+    assert result.text == "re wired kasabian remix"
+    assert result.kind == "remix"
+
+
+def test_hyphenated_remix_anchors_at_the_last_separator():
+    # Multiple " - " separators: the base is the greedy prefix.
+    result = normalize("Song - Part 2 - X Remix")
+    assert result.base_text == "song part 2"
+    assert result.remix_credit == "x"
+
+
+def test_hyphenated_remix_credit_with_internal_hyphen_survives():
+    result = normalize("Umbrella - Jay-Z Remix")
+    assert result.base_text == "umbrella"
+    assert result.remix_credit == "jay-z"
+
+
 def test_bare_remix_marker_has_empty_credit():
     result = normalize("Blue Monday (Remix)")
     assert result.remix_credit == ""

--- a/tests/test_mastering_normalize.py
+++ b/tests/test_mastering_normalize.py
@@ -1,0 +1,215 @@
+"""Exhaustive unit tests for application.mastering.normalize (plan 03 T4).
+
+Pure functions — no services needed. The case lists mirror the decoration
+taxonomy in docs/plans/03-entity-mastering.md.
+"""
+import pytest
+
+from application.mastering.normalize import NormalizedTitle, normalize
+
+
+# ---------------------------------------------------------------------------
+# Basic scrubbing: lowercase, unicode NFKD, punctuation/whitespace runs
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("title,expected", [
+    ("Hello World", "hello world"),
+    ("  Hello   World  ", "hello world"),
+    ("HELLO, WORLD!!!", "hello world"),
+    ("Café del Mar", "cafe del mar"),          # NFKD folds the accent
+    ("Don't Stop Me Now", "dont stop me now"),  # apostrophe drops, no split
+    ("Don’t Stop", "dont stop"),                # curly apostrophe too
+    ("Song/Title\\Here", "song title here"),
+    ("99 Problems", "99 problems"),
+    ("", ""),
+])
+def test_scrubbing(title, expected):
+    assert normalize(title).text == expected
+
+
+def test_none_title_is_empty():
+    result = normalize(None)
+    assert result.text == "" and result.kind == "canonical"
+
+
+# ---------------------------------------------------------------------------
+# Suffix decorations: stripped, and recorded as the variant kind
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("title,text,kind", [
+    ("Cathedral Bells - 2011 Remaster", "cathedral bells", "remaster"),
+    ("Cathedral Bells - Remastered", "cathedral bells", "remaster"),
+    ("Cathedral Bells - Remastered 2009", "cathedral bells", "remaster"),
+    ("Cathedral Bells (Remastered)", "cathedral bells", "remaster"),
+    ("Cathedral Bells (2011 Remaster)", "cathedral bells", "remaster"),
+    ("Cathedral Bells [Remastered 2004]", "cathedral bells", "remaster"),
+    ("Neon Skyline - Deluxe Edition", "neon skyline", "deluxe"),
+    ("Neon Skyline - Deluxe", "neon skyline", "deluxe"),
+    ("Neon Skyline (Deluxe Version)", "neon skyline", "deluxe"),
+    ("Neon Skyline (Expanded Edition)", "neon skyline", "expanded"),
+    ("Gutter Anthem - Single Version", "gutter anthem", "single_version"),
+    ("Gutter Anthem (Single Version)", "gutter anthem", "single_version"),
+    ("Gutter Anthem - Radio Edit", "gutter anthem", "radio_edit"),
+    ("Gutter Anthem (Radio Edit)", "gutter anthem", "radio_edit"),
+    ("Gutter Anthem - Bonus Track", "gutter anthem", "bonus_track"),
+    ("Gutter Anthem (Bonus Track)", "gutter anthem", "bonus_track"),
+    ("Cathedral Bells - Live", "cathedral bells", "live"),
+    ("Cathedral Bells - Live at Wembley", "cathedral bells", "live"),
+    ("Cathedral Bells (Live from Red Rocks)", "cathedral bells", "live"),
+    ("Cathedral Bells (Live)", "cathedral bells", "live"),
+    ("Cathedral Bells - Demo", "cathedral bells", "demo"),
+    ("Cathedral Bells (Demo Version)", "cathedral bells", "demo"),
+])
+def test_decorations_strip_and_record_kind(title, text, kind):
+    result = normalize(title)
+    assert result.text == text
+    assert result.kind == kind
+    assert not result.is_remix
+
+
+def test_stacked_decorations_strip_to_fixpoint():
+    result = normalize("Song Name - Single Version - 2011 Remaster")
+    assert result.text == "song name"
+    # Outermost first: the remaster suffix came off before the single version.
+    assert result.kinds == ("remaster", "single_version")
+    assert result.kind == "remaster"
+
+
+def test_undedecorated_title_is_canonical():
+    result = normalize("Cathedral Bells")
+    assert result.text == "cathedral bells"
+    assert result.kind == "canonical"
+    assert result.kinds == ()
+
+
+@pytest.mark.parametrize("title,expected", [
+    # 'live'/'demo' as words inside the title must NOT be treated as suffixes
+    ("Live and Let Die", "live and let die"),
+    ("Long Live the Queen", "long live the queen"),
+    ("Arsonist - Live Wire", "arsonist live wire"),
+    ("Demolition Man", "demolition man"),
+])
+def test_decoration_words_inside_titles_survive(title, expected):
+    result = normalize(title)
+    assert result.text == expected
+    assert result.kind == "canonical"
+
+
+# ---------------------------------------------------------------------------
+# Remix credits: NEVER stripped — a remix is a different song
+# ---------------------------------------------------------------------------
+
+def test_remix_credit_is_kept_in_the_text():
+    result = normalize("Cathedral Bells (Nightcrawler Remix)")
+    assert result.text == "cathedral bells nightcrawler remix"
+    assert result.base_text == "cathedral bells"
+    assert result.kind == "remix"
+    assert result.remix_credit == "nightcrawler"
+    assert result.is_remix
+
+
+def test_remix_never_normalizes_equal_to_its_parent():
+    remix = normalize("Cathedral Bells (Nightcrawler Remix)")
+    parent = normalize("Cathedral Bells")
+    assert remix.text != parent.text
+    assert remix.base_text == parent.text  # ...but the parent is resolvable
+
+
+def test_hyphenated_remix_marker():
+    result = normalize("One More Time - Skrillex Remix")
+    assert result.text == "one more time skrillex remix"
+    assert result.base_text == "one more time"
+    assert result.kind == "remix"
+
+
+def test_bare_remix_marker_has_empty_credit():
+    result = normalize("Blue Monday (Remix)")
+    assert result.remix_credit == ""
+    assert result.text == "blue monday remix"
+    assert result.base_text == "blue monday"
+
+
+def test_decoration_behind_a_remix_still_strips():
+    result = normalize("Song (X Remix) - Radio Edit")
+    assert result.base_text == "song"
+    assert result.text == "song x remix"
+    assert result.kind == "remix"           # remix identity wins
+    assert "radio_edit" in result.kinds     # ...but the strip is recorded
+
+
+def test_two_remixes_of_one_song_differ_by_credit():
+    a = normalize("Song (A Remix)")
+    b = normalize("Song (B Remix)")
+    assert a.text != b.text
+    assert a.base_text == b.base_text
+
+
+# ---------------------------------------------------------------------------
+# feat./featuring/with: stripped only when redundant with credited artists
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("title", [
+    "Umbrella (feat. Jay-Z)",
+    "Umbrella (featuring Jay-Z)",
+    "Umbrella (with Jay-Z)",
+    "Umbrella [feat. Jay-Z]",
+    "Umbrella - feat. Jay-Z",
+    "Umbrella feat. Jay-Z",
+    "Umbrella ft. Jay-Z",
+])
+def test_feat_stripped_when_artist_is_credited(title):
+    result = normalize(title, artist_names=["Rihanna", "JAY-Z"])
+    assert result.text == "umbrella"
+    assert result.kind == "canonical"
+
+
+def test_feat_kept_when_artist_not_credited():
+    # The featured name is NOT among the credited artists -> it's signal.
+    result = normalize("Umbrella (feat. Jay-Z)", artist_names=["Rihanna"])
+    assert result.text == "umbrella feat jay z"
+
+
+def test_feat_kept_when_no_artists_supplied():
+    assert normalize("Umbrella (feat. Jay-Z)").text == "umbrella feat jay z"
+
+
+def test_unparenthesized_with_is_not_a_credit():
+    # "with" outside parens is a title word, never a feature clause.
+    result = normalize("Dancing With Myself", artist_names=["Myself"])
+    assert result.text == "dancing with myself"
+
+
+def test_feat_clause_with_multiple_names_strips_when_one_is_credited():
+    result = normalize("Song (feat. A & B)", artist_names=["X", "B"])
+    assert result.text == "song"
+
+
+def test_feat_before_decoration_strips_after_decoration():
+    result = normalize(
+        "Umbrella (feat. Jay-Z) - 2011 Remaster", artist_names=["Jay-Z"]
+    )
+    assert result.text == "umbrella"
+    assert result.kind == "remaster"
+
+
+# ---------------------------------------------------------------------------
+# The mock catalog's crafted variants normalize the way clustering expects
+# ---------------------------------------------------------------------------
+
+def test_mock_variant_titles():
+    assert normalize("Neon Skyline").text == "neon skyline"
+    assert normalize("Gutter Anthem").text == "gutter anthem"
+    remaster = normalize("Cathedral Bells - 2011 Remaster")
+    original = normalize("Cathedral Bells")
+    remix = normalize("Cathedral Bells (Nightcrawler Remix)")
+    assert remaster.text == original.text
+    assert remaster.kind == "remaster"
+    assert remix.text != original.text
+    assert remix.base_text == original.text
+
+
+def test_normalized_title_is_frozen():
+    result = normalize("Anything")
+    assert isinstance(result, NormalizedTitle)
+    with pytest.raises(AttributeError):
+        result.text = "mutated"

--- a/tests/test_mastering_overrides.py
+++ b/tests/test_mastering_overrides.py
@@ -1,0 +1,57 @@
+"""Tests for the manual-overrides YAML loader (plan 03 T5)."""
+import pytest
+
+from application.mastering.overrides import Overrides, load_overrides
+
+
+def test_missing_file_means_no_overrides(tmp_path):
+    overrides = load_overrides(tmp_path / "nope.yaml")
+    assert overrides.merges == [] and overrides.splits == []
+    assert not overrides
+
+
+def test_loads_tracks_mappings_and_bare_lists(tmp_path):
+    path = tmp_path / "overrides.yaml"
+    path.write_text(
+        "merge:\n"
+        "  - tracks: [a1, a2]\n"
+        "    reason: same recording\n"
+        "  - [b1, b2, b3]\n"
+        "split:\n"
+        "  - tracks: [c1]\n"
+    )
+    overrides = load_overrides(path)
+    assert overrides.merges == [["a1", "a2"], ["b1", "b2", "b3"]]
+    assert overrides.splits == [["c1"]]
+    assert overrides
+
+
+def test_empty_file_is_fine(tmp_path):
+    path = tmp_path / "overrides.yaml"
+    path.write_text("")
+    assert not load_overrides(path)
+
+
+def test_malformed_entry_raises(tmp_path):
+    path = tmp_path / "overrides.yaml"
+    path.write_text("merge:\n  - tracks: not-a-list\n")
+    with pytest.raises(ValueError, match="Malformed merge"):
+        load_overrides(path)
+
+
+def test_non_mapping_document_raises(tmp_path):
+    path = tmp_path / "overrides.yaml"
+    path.write_text("- just\n- a\n- list\n")
+    with pytest.raises(ValueError, match="must be a mapping"):
+        load_overrides(path)
+
+
+def test_tracked_example_file_parses():
+    from application.config import APPLICATION_DIR
+    overrides = load_overrides(APPLICATION_DIR / "mastering" / "overrides.example.yaml")
+    assert overrides.merges and overrides.splits
+
+
+def test_overrides_dataclass_defaults():
+    assert not Overrides()
+    assert Overrides(merges=[["x"]])

--- a/tests/test_mastering_report.py
+++ b/tests/test_mastering_report.py
@@ -1,6 +1,7 @@
 """Tests for the mastering review report (plan 03 T6) — pure rendering,
 no services."""
 from application.mastering.cluster import cluster_tracks
+from application.mastering.overrides import Overrides
 from application.mastering.report import render_review_report, write_review_report
 from application.mastering.run import overrides_path_from_env
 
@@ -65,6 +66,22 @@ def test_report_includes_warnings():
     result.warnings.append("Track tX links from ghost, which is not in the graph; ignored.")
     report = render_review_report(result)
     assert "## Warnings" in report and "ghost" in report
+
+
+def test_report_marks_split_derived_songs():
+    # A split-derived Song (here the shared-ISRC case, where the id also gets
+    # a :split: suffix) must be visible in the report even as a singleton.
+    result = cluster_tracks(
+        [
+            rec("t1", "Neon Skyline", isrc="SHARED"),
+            rec("t2", "Neon Skyline - Deluxe Edition", isrc="SHARED"),
+        ],
+        overrides=Overrides(splits=[["t2"]]),
+    )
+    report = render_review_report(result)
+    assert "## Manual splits" in report
+    assert "SHARED:split:" in report
+    assert "`t2`" in report
 
 
 def test_write_review_report_writes_the_file(tmp_path):

--- a/tests/test_mastering_report.py
+++ b/tests/test_mastering_report.py
@@ -1,0 +1,86 @@
+"""Tests for the mastering review report (plan 03 T6) — pure rendering,
+no services."""
+from application.mastering.cluster import cluster_tracks
+from application.mastering.report import render_review_report, write_review_report
+from application.mastering.run import overrides_path_from_env
+
+
+def rec(tid, name, isrc=None, duration_ms=200000, explicit=False, artist="artA"):
+    return {
+        "id": tid, "name": name, "isrc": isrc, "linked_from_id": None,
+        "duration_ms": duration_ms, "explicit": explicit,
+        "artist_ids": [artist], "artist_names": ["Artist A"],
+    }
+
+
+def _result():
+    return cluster_tracks([
+        # ISRC-backed pair: unambiguous, should sort BELOW the heuristic ones
+        rec("t1", "Neon Skyline", isrc="SHARED"),
+        rec("t2", "Neon Skyline - Deluxe Edition", isrc="SHARED"),
+        # heuristic-only pair with a wide (>1s) duration spread: most ambiguous
+        rec("t3", "Gutter Anthem", isrc="I3", duration_ms=200000),
+        rec("t4", "Gutter Anthem", isrc="I4", duration_ms=202500, explicit=True),
+        # heuristic-only pair with a tight spread: middle of the report
+        rec("t5", "Cathedral Bells", isrc="I5", duration_ms=183000),
+        rec("t6", "Cathedral Bells - 2011 Remaster", isrc="I6", duration_ms=183200),
+        # a remix with a resolvable parent -> a REMIX_OF line
+        rec("t7", "Cathedral Bells (Nightcrawler Remix)", isrc="I7", duration_ms=184000),
+        # a singleton (summarized in the counts, no section of its own)
+        rec("t8", "Loner", isrc="I8"),
+    ])
+
+
+def test_report_renders_and_counts():
+    report = render_review_report(_result())
+    assert report.startswith("# Mastering review")
+    assert "**8** Tracks assigned" in report
+    assert "**1** REMIX_OF edges" in report
+    assert "**1** clusters flagged for review" in report
+    assert "overrides always win" in report
+
+
+def test_report_sorted_by_ambiguity():
+    report = render_review_report(_result())
+    # heuristic-only + wide spread first, then heuristic-only tight spread,
+    # then the ISRC-backed cluster.
+    gutter = report.index("Gutter Anthem")
+    cathedral = report.index("Cathedral Bells")
+    neon = report.index("Neon Skyline")
+    assert gutter < cathedral < neon
+
+
+def test_report_flags_and_member_rows():
+    report = render_review_report(_result())
+    assert "heuristic-only, duration spread 2500 ms" in report
+    assert "| `t3` |" in report and "| clean |" in report
+    assert "| `t4` |" in report and "| explicit |" in report
+    assert "| remaster |" in report
+    # Singletons don't get their own section.
+    assert "Loner" not in report
+
+
+def test_report_includes_warnings():
+    result = _result()
+    result.warnings.append("Track tX links from ghost, which is not in the graph; ignored.")
+    report = render_review_report(result)
+    assert "## Warnings" in report and "ghost" in report
+
+
+def test_write_review_report_writes_the_file(tmp_path):
+    path = write_review_report(_result(), output_path=tmp_path / "mastering_review.md")
+    assert path.exists()
+    assert path.read_text().startswith("# Mastering review")
+
+
+def test_empty_result_still_renders(tmp_path):
+    result = cluster_tracks([])
+    report = render_review_report(result)
+    assert "_No multi-version clusters were formed this run._" in report
+
+
+def test_overrides_path_env_wins(monkeypatch):
+    monkeypatch.setenv("MASTERING_OVERRIDES_PATH", "/somewhere/else.yaml")
+    assert overrides_path_from_env() == "/somewhere/else.yaml"
+    monkeypatch.delenv("MASTERING_OVERRIDES_PATH")
+    assert overrides_path_from_env().endswith("secrets/mastering_overrides.yaml")


### PR DESCRIPTION
Implements [docs/plans/03](../blob/main/docs/plans/03-entity-mastering.md): ISRC-led identity ladder rolling deluxe/single/clean-explicit re-releases into `(:Song)` masters via `(:Track)-[:VERSION_OF]->(:Song)`.

- ISRC / album_type / linked_from_id / artist_ids persisted on every track insert path (coalesce ON MATCH — backfills refresh, payload gaps never erase)
- `normalize()` with variant-kind extraction; clustering (ISRC → linked_from → heuristic → manual overrides); ambiguity-sorted review report; ISRC backfill script (written, run post-merge)
- Adversarially reviewed: **3 confirmed findings fixed with fail-before regression tests** (shared-ISRC split silently no-op'd → distinct deterministic ids + hard-fail guard; hyphenated remix titles truncated → last-separator anchoring; stale REMIX_OF accumulation → re-pointing)
- Mock catalog gained deterministic ISRCs + crafted variant twins

**Stack: merge after Plan 05 (or anytime); Plan 04's PR is based on this branch.**
Post-merge live steps: ISRC backfill (~250 calls) → `python -m application.mastering.run` → skim `data/mastering_review.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)