### PR TITLE
Plan 04 (phases A+B): Song annotations — model + live hotkey capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,30 @@ docker compose run --rm tests
 A pytest suite (unit + integration) that brings up RabbitMQ + Redis and targets
 the host Neo4j Desktop; integration tests skip if a service is down.
 
+## Annotations (notes, cues, section maps)
+
+Timestamped listening annotations over crawled tracks (plan 04, phases A–B):
+`(:Track)-[:HAS_NOTE|HAS_CUE|HAS_SECTION]->(…)`, sections chained with `NEXT`.
+
+- **Cold entry** — search a track by name in the graph, annotate from prompts:
+  ```bash
+  docker compose run --rm responses_write_to_neo4j \
+      python3 -m application.annotations.annotate "track name"
+  ```
+- **Live capture** — put an album on (any device), keep a terminal open, tap
+  keys as it plays. Polls `/v1/me/player` ~1s; hotkeys: `n` note, `c` cue,
+  `s` section boundary, `u` undo, `+`/`-` nudge 500ms, `q` quit + summary:
+  ```bash
+  docker compose run --rm responses_write_to_neo4j \
+      python3 -m application.annotations.listen
+  ```
+
+> **Scope note:** live capture reads `GET /v1/me/player`, which requires the
+> `user-read-playback-state` OAuth scope — part of the bundled re-auth
+> (docs/plans/README.md, "Do these first"); until you re-authorize, it 403s
+> against live Spotify. It works today against the mock:
+> `docker compose run --rm -e SPOTIFY_API_BASE_URL=http://spotify_mock …`.
+
 ## Stack
 
 Python 3.13 · Poetry 2.4 · RabbitMQ 4 · Redis 8 · Neo4j 6 (driver) · Falcon 4 ·

--- a/application/annotations/annotate.py
+++ b/application/annotations/annotate.py
@@ -1,0 +1,166 @@
+"""`annotate` — cold-entry annotation CLI (plan 04, phase A / T2).
+
+Search a track by name in the Neo4j graph, pick it, then add notes / cues /
+sections from an interactive prompt loop. Positions are typed as M:SS(.mmm),
+bare seconds, or '41000ms' (see timecode.parse_position).
+
+Run inside the compose network (Neo4j on the host via the write worker's env):
+
+    docker compose run --rm responses_write_to_neo4j \
+        python3 -m application.annotations.annotate "track name"
+
+I/O goes through injected input/print callables so the flow is testable
+without a TTY.
+"""
+import argparse
+
+from application.annotations.model import Neo4jAnnotationWriter, normalize_kind
+from application.annotations.timecode import format_ms, parse_position
+from application.config import SECRETS_DIR
+from application.loggers import get_logger
+
+logger = get_logger(__name__)
+
+NEO4J_CREDENTIALS_FILE = SECRETS_DIR / "neo4j_credentials.yaml"
+
+HELP_TEXT = """commands:
+  n   add a note (freeform text)
+  c   add a cue (position + label)
+  s   add a section boundary (start position + label; end closed by the next boundary)
+  l   list this track's annotations
+  u   undo the last entry from this session
+  h   this help
+  q   quit"""
+
+
+def pick_track(writer, search_term, in_=input, out=print):
+    """Search the graph by name and let the user pick a match. None if no match."""
+    matches = writer.search_tracks(search_term)
+    if not matches:
+        out(f'No tracks in the graph match {search_term!r}. (Only crawled tracks are annotatable.)')
+        return None
+    if len(matches) == 1:
+        return matches[0]
+
+    out(f'{len(matches)} matches:')
+    for index, track in enumerate(matches):
+        artists = ", ".join(a for a in track["artists"] if a) or "?"
+        out(f'  [{index}] {artists} - {track["name"]} ({track["album"] or "?"})')
+    while True:
+        choice = in_("pick a number (or q): ").strip().lower()
+        if choice == "q":
+            return None
+        if choice.isdigit() and int(choice) < len(matches):
+            return matches[int(choice)]
+        out("invalid choice")
+
+
+def _prompt_position(in_, out, message):
+    """Prompt until a parseable position (or blank to cancel). None = cancelled."""
+    while True:
+        raw = in_(message).strip()
+        if not raw:
+            return None
+        try:
+            return parse_position(raw)
+        except ValueError as exc:
+            out(str(exc))
+
+
+def _list_annotations(writer, track, out):
+    annotations = writer.fetch_annotations(track["id"])
+    out(f'--- {track["name"]} ---')
+    for section in annotations["sections"]:
+        end = format_ms(section["end_ms"]) if section["end_ms"] is not None else "…"
+        out(f'  section #{section["order"]} [{section["kind"]}] '
+            f'{format_ms(section["start_ms"])}-{end}  {section["label"]}')
+    for cue in annotations["cues"]:
+        out(f'  cue @ {format_ms(cue["at_ms"])}  {cue["label"]}')
+    for note in annotations["notes"]:
+        position = f' @ {format_ms(note["at_ms"])}' if note["at_ms"] is not None else ""
+        out(f'  note{position}: {note["text"]}')
+    if not any(annotations.values()):
+        out("  (none yet)")
+
+
+def run_annotation_loop(writer, track, in_=input, out=print):
+    """The interactive prompt loop for one track. Returns the session records."""
+    session = []
+    out(f'Annotating: {track["name"]}  ({format_ms(track.get("duration_ms"))})')
+    out(HELP_TEXT)
+
+    while True:
+        command = in_("annotate> ").strip().lower()
+
+        if command == "q":
+            break
+        elif command == "h":
+            out(HELP_TEXT)
+        elif command == "l":
+            _list_annotations(writer, track, out)
+        elif command == "n":
+            text = in_("note text: ").strip()
+            if not text:
+                out("empty - discarded")
+                continue
+            session.append(writer.add_note(track["id"], text))
+            out("noted.")
+        elif command == "c":
+            at_ms = _prompt_position(in_, out, "cue position (M:SS): ")
+            if at_ms is None:
+                out("cancelled")
+                continue
+            label = in_("cue label: ").strip() or "cue"
+            session.append(writer.add_cue(track["id"], at_ms, label))
+            out(f'cue @ {format_ms(at_ms)}: {label}')
+        elif command == "s":
+            start_ms = _prompt_position(in_, out, "section start (M:SS): ")
+            if start_ms is None:
+                out("cancelled")
+                continue
+            label = in_("section label: ").strip()
+            if not label:
+                out("empty - discarded")
+                continue
+            order = writer.next_section_order(track["id"])
+            record = writer.add_section(track["id"], order, start_ms, label)
+            session.append(record)
+            out(f'section #{order} [{normalize_kind(label)}] @ {format_ms(start_ms)}: {label}')
+        elif command == "u":
+            if not session:
+                out("nothing to undo (this session)")
+                continue
+            record = session.pop()
+            writer.undo(record)
+            out(f'undid {record["type"]}: {record.get("label") or record.get("text") or record["id"]}')
+        elif command:
+            out(f'unknown command {command!r} - h for help')
+
+    return session
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="annotate",
+        description="Cold-entry annotation of a track already in the graph (plan 04 phase A).",
+    )
+    parser.add_argument("search_term", nargs="+", help="track name (substring, case-insensitive)")
+    args = parser.parse_args(argv)
+    search_term = " ".join(args.search_term)
+
+    from application.graph_database.connect import connect_to_neo4j
+
+    driver = connect_to_neo4j(NEO4J_CREDENTIALS_FILE)
+    try:
+        writer = Neo4jAnnotationWriter(driver)
+        track = pick_track(writer, search_term)
+        if track is None:
+            return
+        session = run_annotation_loop(writer, track)
+        print(f'{len(session)} annotation(s) written to {track["name"]}.')
+    finally:
+        driver.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/application/annotations/annotate.py
+++ b/application/annotations/annotate.py
@@ -14,7 +14,11 @@ without a TTY.
 """
 import argparse
 
-from application.annotations.model import Neo4jAnnotationWriter, normalize_kind
+from application.annotations.model import (
+    AnnotationWriteError,
+    Neo4jAnnotationWriter,
+    normalize_kind,
+)
 from application.annotations.timecode import format_ms, parse_position
 from application.config import SECRETS_DIR
 from application.loggers import get_logger
@@ -123,7 +127,12 @@ def run_annotation_loop(writer, track, in_=input, out=print):
                 out("empty - discarded")
                 continue
             order = writer.next_section_order(track["id"])
-            record = writer.add_section(track["id"], order, start_ms, label)
+            try:
+                record = writer.add_section(track["id"], order, start_ms, label)
+            except AnnotationWriteError as exc:
+                # e.g. a section already starts at this ms - nothing written.
+                out(f"!! not saved: {exc}")
+                continue
             session.append(record)
             out(f'section #{order} [{normalize_kind(label)}] @ {format_ms(start_ms)}: {label}')
         elif command == "u":

--- a/application/annotations/listen.py
+++ b/application/annotations/listen.py
@@ -50,6 +50,11 @@ SPOTIFY_API_TOKEN_FILE = SECRETS_DIR / "spotify_api_token.secret"
 
 NUDGE_STEP_MS = 500
 POLL_INTERVAL_SECONDS = 1.0
+# Transient poll failures back off exponentially from the poll interval up to
+# this cap; a 429's Retry-After is honored but also capped (a capture session
+# should keep breathing, and the next poll is cheap).
+POLL_BACKOFF_CAP_SECONDS = 30.0
+RETRY_AFTER_CAP_SECONDS = 60.0
 
 HOTKEYS_HELP = (
     "hotkeys: [n]ote  [c]ue  [s]ection  [u]ndo  [+/-] nudge 500ms  [q]uit"
@@ -93,11 +98,41 @@ class PlaybackTracker:
         self._next_orders = {}  # track_id -> next section order (seeded from the graph)
         self.quit_requested = False
 
+        self._poll_failures = 0
+        self.poll_backoff_seconds = 0.0  # extra wait the TTY loop applies before re-polling
+        self.poll_error = None  # short status-line description of the last failure
+
     # --- polling -----------------------------------------------------------
 
     def poll(self):
-        """Refresh playback state. Returns the payload, or None when idle."""
-        state = self.fetch_playback()
+        """Refresh playback state. Returns the payload, or None when idle OR
+        when the poll failed transiently.
+
+        A capture session must survive flaky HTTP: 429s (Retry-After honored,
+        capped), 5xx, timeouts, connection errors — all requests-level
+        failures are absorbed with bounded exponential backoff (surfaced via
+        poll_backoff_seconds / poll_error / status_line) instead of unwinding
+        the loop and dumping the user mid-listening. The last-known playback
+        state is retained so position estimation keeps working between
+        retries. A 403 (missing scope) still exits: fetch raises SystemExit,
+        which is not a RequestException."""
+        try:
+            state = self.fetch_playback()
+        except requests.exceptions.RequestException as exc:
+            self._poll_failures += 1
+            backoff = min(
+                POLL_BACKOFF_CAP_SECONDS,
+                POLL_INTERVAL_SECONDS * (2 ** (self._poll_failures - 1)),
+            )
+            retry_after = self._retry_after_seconds(exc)
+            if retry_after is not None:
+                backoff = max(backoff, min(retry_after, RETRY_AFTER_CAP_SECONDS))
+            self.poll_backoff_seconds = backoff
+            self.poll_error = f"{exc.__class__.__name__} (retry in {backoff:.0f}s)"
+            return None
+        self._poll_failures = 0
+        self.poll_backoff_seconds = 0.0
+        self.poll_error = None
         if not state or not state.get("item"):
             self.track = None
             self.is_playing = False
@@ -112,6 +147,18 @@ class PlaybackTracker:
         if changed:
             self._refresh_graph_membership()
         return state
+
+    @staticmethod
+    def _retry_after_seconds(exc):
+        """Retry-After from the failed response, if any (429 rate limits)."""
+        response = getattr(exc, "response", None)
+        if response is None or response.headers is None:
+            return None
+        value = response.headers.get("Retry-After")
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
 
     def _refresh_graph_membership(self):
         """On track change: warn up front when the playing track isn't in the
@@ -267,8 +314,9 @@ class PlaybackTracker:
     # --- display -----------------------------------------------------------
 
     def status_line(self):
+        suffix = f"  !! poll failing: {self.poll_error}" if self.poll_error else ""
         if self.track is None:
-            return "-- no active playback --"
+            return "-- no active playback --" + suffix
         artists = ", ".join(a.get("name", "?") for a in self.track.get("artists", []))
         state = ">" if self.is_playing else "||"
         marker = "  [NOT IN GRAPH]" if self.current_track_in_graph is False else ""
@@ -276,7 +324,7 @@ class PlaybackTracker:
         return (
             f'{state} {artists} - {self.track["name"]}{marker}  '
             f'{format_ms(self.position_ms())}/{format_ms(self.track.get("duration_ms"))}  '
-            f'({len(self.session)} captured{failed})'
+            f'({len(self.session)} captured{failed}){suffix}'
         )
 
     def session_summary(self):
@@ -306,6 +354,7 @@ def fetch_playback_from_api():
         response = requests.get(
             f"{SPOTIFY_API_BASE_URL}/v1/me/player",
             headers={"Authorization": f"Bearer {_read_token()}"},
+            timeout=10,  # a hung poll would freeze the whole capture loop
         )
         if response.status_code == 204:
             return None
@@ -405,11 +454,10 @@ def main(argv=None):
         last_poll = 0.0
         while not tracker.quit_requested:
             now = time.monotonic()
-            if now - last_poll >= args.interval:
-                try:
-                    tracker.poll()
-                except requests.exceptions.ConnectionError as exc:
-                    _redraw(f'!! player poll failed: {exc.__class__.__name__} (retrying)')
+            # poll() absorbs transient HTTP failures itself (bounded backoff,
+            # surfaced on the status line); only a 403 SystemExit escapes.
+            if now - last_poll >= max(args.interval, tracker.poll_backoff_seconds):
+                tracker.poll()
                 last_poll = now
             for notice in tracker.drain_notices():
                 sys.stdout.write("\r\x1b[K!! " + notice + "\n")

--- a/application/annotations/listen.py
+++ b/application/annotations/listen.py
@@ -24,6 +24,7 @@ Live Spotify use requires the `user-read-playback-state` scope, which lands
 with the bundled re-auth (plans README "Do these first"; plan 04 T3).
 """
 import argparse
+import os
 import select
 import sys
 import termios
@@ -325,6 +326,24 @@ def fetch_playback_from_api():
 
 # --- thin TTY layer (stdlib only: termios/tty/select) ------------------------
 
+def _read_key(stdin_fd):
+    """One keypress as a str, read straight off the raw fd. None on EOF.
+
+    select() watches the KERNEL buffer of the fd, so the read must come from
+    the same place. Reading through the buffered sys.stdin TextIOWrapper
+    slurps EVERY pending byte into a Python-level buffer select() can't see:
+    a burst (keyboard auto-repeat on the nudge keys, a paste) would yield one
+    processed key and strand the rest until some future keypress — and
+    input() in prompt() reads fd 0 directly, bypassing that buffer, so
+    stranded hotkeys would survive prompts and fire much later. os.read
+    leaves the remaining bytes in the kernel buffer where select() keeps
+    reporting them, one key per loop iteration."""
+    data = os.read(stdin_fd, 1)
+    if not data:
+        return None
+    return data.decode("utf-8", errors="replace")
+
+
 def _redraw(line):
     sys.stdout.write("\r\x1b[K" + line)
     sys.stdout.flush()
@@ -395,9 +414,11 @@ def main(argv=None):
             for notice in tracker.drain_notices():
                 sys.stdout.write("\r\x1b[K!! " + notice + "\n")
             _redraw(tracker.status_line())
-            readable, _, _ = select.select([sys.stdin], [], [], 0.25)
+            readable, _, _ = select.select([stdin_fd], [], [], 0.25)
             if readable:
-                key = sys.stdin.read(1)
+                key = _read_key(stdin_fd)
+                if key is None:
+                    break  # stdin closed (EOF): end the session cleanly
                 feedback = tracker.handle_key(key)
                 if feedback:
                     sys.stdout.write("\r\x1b[K  " + feedback + "\n")

--- a/application/annotations/listen.py
+++ b/application/annotations/listen.py
@@ -1,0 +1,332 @@
+"""`listen` — live annotation capture while listening (plan 04, phase B / T4).
+
+Polls GET {SPOTIFY_API_BASE_URL}/v1/me/player (~1s) for the currently playing
+track and turns single keypresses into graph annotations:
+
+    n  note (text prompt)        c  cue at the current position (label prompt)
+    s  section boundary (label prompt; NEXT-chained, end set by the next boundary)
+    u  undo the last capture     +/-  nudge the last capture by 500ms
+    q  quit (prints a session summary)
+
+Positions are captured AT KEYPRESS TIME (before the prompt blocks), estimated
+from the last poll plus wall-clock elapsed — accuracy is poll-latency bound
+(±1-2s); the nudge keys are the fine-tuning story for now.
+
+Layering: PlaybackTracker is the pure poll-and-dispatch loop over injected
+fetch / writer / prompt / clock callables — unit-testable without a TTY or any
+services. main() is the thin stdlib-only terminal layer (termios/tty/select).
+
+Run against the mock (no OAuth scope needed):
+    docker compose run --rm -e SPOTIFY_API_BASE_URL=http://spotify_mock \
+        responses_write_to_neo4j python3 -m application.annotations.listen
+
+Live Spotify use requires the `user-read-playback-state` scope, which lands
+with the bundled re-auth (plans README "Do these first"; plan 04 T3).
+"""
+import argparse
+import select
+import sys
+import termios
+import time
+import tty
+from collections import Counter
+
+import requests
+
+from application.annotations.model import Neo4jAnnotationWriter
+from application.annotations.timecode import format_ms
+from application.config import SECRETS_DIR, SPOTIFY_API_BASE_URL
+from application.loggers import get_logger
+
+logger = get_logger(__name__)
+
+NEO4J_CREDENTIALS_FILE = SECRETS_DIR / "neo4j_credentials.yaml"
+SPOTIFY_API_TOKEN_FILE = SECRETS_DIR / "spotify_api_token.secret"
+
+NUDGE_STEP_MS = 500
+POLL_INTERVAL_SECONDS = 1.0
+
+HOTKEYS_HELP = (
+    "hotkeys: [n]ote  [c]ue  [s]ection  [u]ndo  [+/-] nudge 500ms  [q]uit"
+)
+
+
+class PlaybackTracker:
+    """Poll-and-dispatch core of `listen`: pure over injected callables.
+
+    fetch_playback() -> the /v1/me/player payload dict ({is_playing,
+        progress_ms, item: <track object>}) or None (no active device).
+    writer -> the annotation writer protocol (Neo4jAnnotationWriter or a fake):
+        add_note / add_cue / add_section / undo / nudge / next_section_order.
+    prompt(message) -> str: blocking text entry (the TTY layer drops out of raw
+        mode for it; tests inject a stub).
+    clock() -> float seconds (monotonic): drives between-poll position
+        estimation, injectable for deterministic tests.
+    """
+
+    def __init__(self, fetch_playback, writer, prompt, clock=time.monotonic):
+        self.fetch_playback = fetch_playback
+        self.writer = writer
+        self.prompt = prompt
+        self.clock = clock
+
+        self.track = None  # the /v1/me/player item currently playing
+        self.is_playing = False
+        self._progress_ms = 0
+        self._polled_at = None
+
+        self.undo_stack = []
+        self.session = []  # surviving records, for the exit summary
+        self._next_orders = {}  # track_id -> next section order (seeded from the graph)
+        self.quit_requested = False
+
+    # --- polling -----------------------------------------------------------
+
+    def poll(self):
+        """Refresh playback state. Returns the payload, or None when idle."""
+        state = self.fetch_playback()
+        if not state or not state.get("item"):
+            self.track = None
+            self.is_playing = False
+            self._progress_ms = 0
+            self._polled_at = None
+            return None
+        self.track = state["item"]
+        self.is_playing = bool(state.get("is_playing"))
+        self._progress_ms = int(state.get("progress_ms") or 0)
+        self._polled_at = self.clock()
+        return state
+
+    def position_ms(self):
+        """Estimated position: last polled progress plus wall-clock elapsed
+        while playing, clamped to the track duration. None when idle."""
+        if self.track is None:
+            return None
+        position = self._progress_ms
+        if self.is_playing and self._polled_at is not None:
+            position += int((self.clock() - self._polled_at) * 1000)
+        duration = self.track.get("duration_ms")
+        return min(position, duration) if duration else position
+
+    # --- key dispatch ------------------------------------------------------
+
+    def handle_key(self, key):
+        """Dispatch one keypress; returns a feedback line for the TTY layer."""
+        if key == "q":
+            self.quit_requested = True
+            return "bye"
+        if key == "u":
+            return self._undo()
+        if key in ("+", "-"):
+            return self._nudge(NUDGE_STEP_MS if key == "+" else -NUDGE_STEP_MS)
+        if key in ("n", "c", "s"):
+            if self.track is None:
+                return "no active playback - start something on any device first"
+            # Capture the position at KEYPRESS time, before the prompt blocks.
+            at_ms = self.position_ms()
+            if key == "n":
+                return self._add_note(at_ms)
+            if key == "c":
+                return self._add_cue(at_ms)
+            return self._add_section(at_ms)
+        return ""  # unmapped key: ignore silently
+
+    def _record(self, record):
+        self.undo_stack.append(record)
+        self.session.append(record)
+        return record
+
+    def _add_note(self, at_ms):
+        text = (self.prompt("note> ") or "").strip()
+        if not text:
+            return "empty - discarded"
+        self._record(self.writer.add_note(self.track["id"], text, at_ms=at_ms))
+        return f'note @ {format_ms(at_ms)}: {text}'
+
+    def _add_cue(self, at_ms):
+        label = (self.prompt("cue label> ") or "").strip() or "cue"
+        self._record(self.writer.add_cue(self.track["id"], at_ms, label))
+        return f'cue @ {format_ms(at_ms)}: {label}'
+
+    def _add_section(self, at_ms):
+        label = (self.prompt("section label> ") or "").strip()
+        if not label:
+            return "empty - discarded"
+        track_id = self.track["id"]
+        order = self._claim_section_order(track_id)
+        record = self._record(self.writer.add_section(track_id, order, at_ms, label))
+        return f'section #{order} [{record["kind"]}] @ {format_ms(at_ms)}: {label}'
+
+    def _claim_section_order(self, track_id):
+        if track_id not in self._next_orders:
+            # Seed from the graph so live capture appends after cold entries.
+            self._next_orders[track_id] = self.writer.next_section_order(track_id)
+        order = self._next_orders[track_id]
+        self._next_orders[track_id] = order + 1
+        return order
+
+    def _undo(self):
+        if not self.undo_stack:
+            return "nothing to undo"
+        record = self.undo_stack.pop()
+        self.writer.undo(record)
+        if record in self.session:
+            self.session.remove(record)
+        if record["type"] == "section":
+            # Give the order back so the next boundary doesn't skip a slot.
+            track_id = record["track_id"]
+            self._next_orders[track_id] = min(
+                self._next_orders.get(track_id, record["order"]), record["order"]
+            )
+        label = record.get("label") or record.get("text") or record["id"]
+        return f'undid {record["type"]}: {label}'
+
+    def _nudge(self, delta_ms):
+        record = self.undo_stack[-1] if self.undo_stack else None
+        position_key = None
+        if record is not None:
+            position_key = "start_ms" if record["type"] == "section" else "at_ms"
+            if record.get(position_key) is None:
+                record = None
+        if record is None:
+            return "nothing to nudge"
+        new_ms = max(0, int(record[position_key]) + delta_ms)
+        self.writer.nudge(record, new_ms)
+        record[position_key] = new_ms
+        return f'{record["type"]} nudged to {format_ms(new_ms)}'
+
+    # --- display -----------------------------------------------------------
+
+    def status_line(self):
+        if self.track is None:
+            return "-- no active playback --"
+        artists = ", ".join(a.get("name", "?") for a in self.track.get("artists", []))
+        state = ">" if self.is_playing else "||"
+        return (
+            f'{state} {artists} - {self.track["name"]}  '
+            f'{format_ms(self.position_ms())}/{format_ms(self.track.get("duration_ms"))}  '
+            f'({len(self.session)} captured)'
+        )
+
+    def session_summary(self):
+        by_track = {}
+        for record in self.session:
+            by_track.setdefault(record["track_id"], []).append(record)
+        return {
+            "total": len(self.session),
+            "by_type": dict(Counter(record["type"] for record in self.session)),
+            "by_track": by_track,
+        }
+
+
+# --- live fetch over HTTP ----------------------------------------------------
+
+def _read_token():
+    with open(SPOTIFY_API_TOKEN_FILE, "r") as f:
+        return f.read().strip()
+
+
+def fetch_playback_from_api():
+    """GET /v1/me/player with the crawl's token. None on 204 (no active
+    device). One 401 -> refresh -> retry, mirroring the engine's behavior."""
+    for attempt in (1, 2):
+        response = requests.get(
+            f"{SPOTIFY_API_BASE_URL}/v1/me/player",
+            headers={"Authorization": f"Bearer {_read_token()}"},
+        )
+        if response.status_code == 204:
+            return None
+        if response.status_code == 401 and attempt == 1:
+            logger.warning("HTTP 401: access token expired; refreshing...")
+            from application.spotify_authentication.refresh_token import refresh_spotify_auth
+            refresh_spotify_auth()
+            continue
+        if response.status_code == 403:
+            raise SystemExit(
+                "403 from /v1/me/player: the token lacks the user-read-playback-state "
+                "scope (pending the bundled re-auth, plan 04 T3). Against the mock "
+                "(SPOTIFY_API_BASE_URL=http://spotify_mock) no scope is needed."
+            )
+        response.raise_for_status()
+        return response.json()
+
+
+# --- thin TTY layer (stdlib only: termios/tty/select) ------------------------
+
+def _redraw(line):
+    sys.stdout.write("\r\x1b[K" + line)
+    sys.stdout.flush()
+
+
+def _print_summary(summary):
+    print(f'\nSession summary: {summary["total"]} annotation(s) '
+          f'{summary["by_type"] or ""}')
+    for track_id, records in summary["by_track"].items():
+        print(f'  {track_id}:')
+        for record in records:
+            position = record.get("start_ms") if record["type"] == "section" else record.get("at_ms")
+            position_text = f'@ {format_ms(position)}' if position is not None else ""
+            body = record.get("label") or record.get("text") or ""
+            print(f'    {record["type"]:<8} {position_text:<10} {body}')
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="listen",
+        description="Live annotation capture from the currently playing track (plan 04 phase B).",
+    )
+    parser.add_argument(
+        "--interval", type=float, default=POLL_INTERVAL_SECONDS,
+        help="seconds between /v1/me/player polls (default 1.0)",
+    )
+    args = parser.parse_args(argv)
+
+    from application.graph_database.connect import connect_to_neo4j
+
+    driver = connect_to_neo4j(NEO4J_CREDENTIALS_FILE)
+    writer = Neo4jAnnotationWriter(driver)
+
+    stdin_fd = sys.stdin.fileno()
+    saved_termios = termios.tcgetattr(stdin_fd)
+
+    def prompt(message):
+        # Drop back to cooked mode for line-edited text entry, then re-arm.
+        termios.tcsetattr(stdin_fd, termios.TCSADRAIN, saved_termios)
+        try:
+            sys.stdout.write("\n")
+            return input(message)
+        finally:
+            tty.setcbreak(stdin_fd)
+
+    tracker = PlaybackTracker(fetch_playback_from_api, writer, prompt)
+
+    print(f'Polling {SPOTIFY_API_BASE_URL}/v1/me/player every {args.interval}s')
+    print(HOTKEYS_HELP)
+
+    tty.setcbreak(stdin_fd)
+    try:
+        last_poll = 0.0
+        while not tracker.quit_requested:
+            now = time.monotonic()
+            if now - last_poll >= args.interval:
+                try:
+                    tracker.poll()
+                except requests.exceptions.ConnectionError as exc:
+                    _redraw(f'!! player poll failed: {exc.__class__.__name__} (retrying)')
+                last_poll = now
+            _redraw(tracker.status_line())
+            readable, _, _ = select.select([sys.stdin], [], [], 0.25)
+            if readable:
+                key = sys.stdin.read(1)
+                feedback = tracker.handle_key(key)
+                if feedback:
+                    sys.stdout.write("\r\x1b[K  " + feedback + "\n")
+    finally:
+        termios.tcsetattr(stdin_fd, termios.TCSADRAIN, saved_termios)
+        driver.close()
+
+    _print_summary(tracker.session_summary())
+
+
+if __name__ == "__main__":
+    main()

--- a/application/annotations/listen.py
+++ b/application/annotations/listen.py
@@ -255,7 +255,11 @@ class PlaybackTracker:
         if record is None:
             return "nothing to nudge"
         new_ms = max(0, int(record[position_key]) + delta_ms)
-        self.writer.nudge(record, new_ms)
+        if not self.writer.nudge(record, new_ms):
+            # The graph rejected the move (it would invert a section or cross
+            # a neighboring boundary) - keep the local copy in sync: unchanged.
+            return (f'nudge blocked: {format_ms(new_ms)} would cross a section '
+                    f'boundary - {record["type"]} stays at {format_ms(record[position_key])}')
         record[position_key] = new_ms
         return f'{record["type"]} nudged to {format_ms(new_ms)}'
 

--- a/application/annotations/listen.py
+++ b/application/annotations/listen.py
@@ -33,7 +33,11 @@ from collections import Counter
 
 import requests
 
-from application.annotations.model import Neo4jAnnotationWriter
+from application.annotations.model import (
+    AnnotationWriteError,
+    Neo4jAnnotationWriter,
+    TrackNotInGraphError,
+)
 from application.annotations.timecode import format_ms
 from application.config import SECRETS_DIR, SPOTIFY_API_BASE_URL
 from application.loggers import get_logger
@@ -57,7 +61,11 @@ class PlaybackTracker:
     fetch_playback() -> the /v1/me/player payload dict ({is_playing,
         progress_ms, item: <track object>}) or None (no active device).
     writer -> the annotation writer protocol (Neo4jAnnotationWriter or a fake):
-        add_note / add_cue / add_section / undo / nudge / next_section_order.
+        add_note / add_cue / add_section / undo / nudge / next_section_order /
+        track_in_graph. The add_* calls raise AnnotationWriteError when the
+        write persisted nothing (e.g. the track isn't in the graph) — the
+        tracker surfaces those as explicit capture FAILURES instead of
+        silently pretending success.
     prompt(message) -> str: blocking text entry (the TTY layer drops out of raw
         mode for it; tests inject a stub).
     clock() -> float seconds (monotonic): drives between-poll position
@@ -77,6 +85,10 @@ class PlaybackTracker:
 
         self.undo_stack = []
         self.session = []  # surviving records, for the exit summary
+        self.failures = []  # captures that did NOT persist, for the exit summary
+        self.notices = []  # one-shot warnings for the TTY layer to print
+        # True/False once probed; None = unknown (writer without the probe).
+        self.current_track_in_graph = None
         self._next_orders = {}  # track_id -> next section order (seeded from the graph)
         self.quit_requested = False
 
@@ -91,11 +103,34 @@ class PlaybackTracker:
             self._progress_ms = 0
             self._polled_at = None
             return None
+        changed = self.track is None or self.track["id"] != state["item"]["id"]
         self.track = state["item"]
         self.is_playing = bool(state.get("is_playing"))
         self._progress_ms = int(state.get("progress_ms") or 0)
         self._polled_at = self.clock()
+        if changed:
+            self._refresh_graph_membership()
         return state
+
+    def _refresh_graph_membership(self):
+        """On track change: warn up front when the playing track isn't in the
+        graph — captures against it cannot persist (the insert Cypher MATCHes
+        the Track and must never create placeholders)."""
+        probe = getattr(self.writer, "track_in_graph", None)
+        if probe is None:
+            self.current_track_in_graph = None
+            return
+        self.current_track_in_graph = bool(probe(self.track["id"]))
+        if not self.current_track_in_graph:
+            self.notices.append(
+                f'{self.track.get("name", self.track["id"])!r} is NOT in the graph - '
+                f"captures will FAIL until it is crawled"
+            )
+
+    def drain_notices(self):
+        """Hand pending one-shot warnings to the TTY layer (clears them)."""
+        notices, self.notices = self.notices, []
+        return notices
 
     def position_ms(self):
         """Estimated position: last polled progress plus wall-clock elapsed
@@ -134,18 +169,42 @@ class PlaybackTracker:
     def _record(self, record):
         self.undo_stack.append(record)
         self.session.append(record)
+        # A successful write proves the track is in the graph (it may have
+        # been crawled since the last membership probe).
+        self.current_track_in_graph = True
         return record
+
+    def _fail(self, capture_type, at_ms, body, exc):
+        """An explicit, visible capture failure: nothing was written. Recorded
+        for the session summary (with the typed text/label, so it isn't lost)
+        but NEVER on the undo stack."""
+        self.failures.append({
+            "type": capture_type,
+            "track_id": self.track["id"],
+            "at_ms": at_ms,
+            "body": body,
+            "error": str(exc),
+        })
+        if isinstance(exc, TrackNotInGraphError):
+            self.current_track_in_graph = False
+        return f"!! FAILED {capture_type} @ {format_ms(at_ms)}: {body} - NOT saved ({exc})"
 
     def _add_note(self, at_ms):
         text = (self.prompt("note> ") or "").strip()
         if not text:
             return "empty - discarded"
-        self._record(self.writer.add_note(self.track["id"], text, at_ms=at_ms))
+        try:
+            self._record(self.writer.add_note(self.track["id"], text, at_ms=at_ms))
+        except AnnotationWriteError as exc:
+            return self._fail("note", at_ms, text, exc)
         return f'note @ {format_ms(at_ms)}: {text}'
 
     def _add_cue(self, at_ms):
         label = (self.prompt("cue label> ") or "").strip() or "cue"
-        self._record(self.writer.add_cue(self.track["id"], at_ms, label))
+        try:
+            self._record(self.writer.add_cue(self.track["id"], at_ms, label))
+        except AnnotationWriteError as exc:
+            return self._fail("cue", at_ms, label, exc)
         return f'cue @ {format_ms(at_ms)}: {label}'
 
     def _add_section(self, at_ms):
@@ -154,7 +213,12 @@ class PlaybackTracker:
             return "empty - discarded"
         track_id = self.track["id"]
         order = self._claim_section_order(track_id)
-        record = self._record(self.writer.add_section(track_id, order, at_ms, label))
+        try:
+            record = self._record(self.writer.add_section(track_id, order, at_ms, label))
+        except AnnotationWriteError as exc:
+            # Give the unused order back so the next boundary doesn't skip a slot.
+            self._next_orders[track_id] = min(self._next_orders.get(track_id, order), order)
+            return self._fail("section", at_ms, label, exc)
         return f'section #{order} [{record["kind"]}] @ {format_ms(at_ms)}: {label}'
 
     def _claim_section_order(self, track_id):
@@ -202,10 +266,12 @@ class PlaybackTracker:
             return "-- no active playback --"
         artists = ", ".join(a.get("name", "?") for a in self.track.get("artists", []))
         state = ">" if self.is_playing else "||"
+        marker = "  [NOT IN GRAPH]" if self.current_track_in_graph is False else ""
+        failed = f", {len(self.failures)} FAILED" if self.failures else ""
         return (
-            f'{state} {artists} - {self.track["name"]}  '
+            f'{state} {artists} - {self.track["name"]}{marker}  '
             f'{format_ms(self.position_ms())}/{format_ms(self.track.get("duration_ms"))}  '
-            f'({len(self.session)} captured)'
+            f'({len(self.session)} captured{failed})'
         )
 
     def session_summary(self):
@@ -216,6 +282,8 @@ class PlaybackTracker:
             "total": len(self.session),
             "by_type": dict(Counter(record["type"] for record in self.session)),
             "by_track": by_track,
+            "failed": len(self.failures),
+            "failures": list(self.failures),
         }
 
 
@@ -268,6 +336,12 @@ def _print_summary(summary):
             position_text = f'@ {format_ms(position)}' if position is not None else ""
             body = record.get("label") or record.get("text") or ""
             print(f'    {record["type"]:<8} {position_text:<10} {body}')
+    if summary.get("failed"):
+        print(f'\n!! {summary["failed"]} capture(s) FAILED and were NOT written to the graph:')
+        for failure in summary["failures"]:
+            position_text = f'@ {format_ms(failure["at_ms"])}' if failure["at_ms"] is not None else ""
+            print(f'    {failure["type"]:<8} {position_text:<10} {failure["body"]}  '
+                  f'[{failure["track_id"]}: {failure["error"]}]')
 
 
 def main(argv=None):
@@ -314,6 +388,8 @@ def main(argv=None):
                 except requests.exceptions.ConnectionError as exc:
                     _redraw(f'!! player poll failed: {exc.__class__.__name__} (retrying)')
                 last_poll = now
+            for notice in tracker.drain_notices():
+                sys.stdout.write("\r\x1b[K!! " + notice + "\n")
             _redraw(tracker.status_line())
             readable, _, _ = select.select([sys.stdin], [], [], 0.25)
             if readable:

--- a/application/annotations/model.py
+++ b/application/annotations/model.py
@@ -35,6 +35,11 @@ class TrackNotInGraphError(AnnotationWriteError):
             f"track {track_id!r} is not in the graph - only crawled tracks are annotatable"
         )
 
+
+class SectionBoundaryError(AnnotationWriteError):
+    """The section boundary would violate the chain invariant (NEXT strictly
+    increasing in start_ms): another section already starts at that ms."""
+
 # Section.kind vocabulary — EDM and song-form both first-class (plan 04 A).
 SECTION_KINDS = (
     "intro", "verse", "chorus", "bridge", "buildup", "drop",
@@ -108,6 +113,11 @@ def build_section_params(track_id, order, start_ms, label, kind=None, end_ms=Non
         kind = normalize_kind(label)
     elif kind not in SECTION_KINDS:
         raise ValueError(f"unknown section kind {kind!r}; expected one of {SECTION_KINDS}")
+    if end_ms is not None and int(end_ms) < int(start_ms):
+        # Chain invariant: end_ms >= start_ms, always.
+        raise ValueError(
+            f"section end_ms ({int(end_ms)}) must be >= start_ms ({int(start_ms)})"
+        )
     return {
         "section": {
             "track_id": track_id,
@@ -166,7 +176,14 @@ class Neo4jAnnotationWriter:
         params = build_section_params(track_id, order, start_ms, label, kind=kind, end_ms=end_ms)
         counters = self._execute(INSERT_SECTION_QUERY, **params)
         if counters.nodes_created == 0:
-            raise TrackNotInGraphError(track_id)
+            # Zero writes: either the Track MATCH found nothing, or the
+            # duplicate-boundary guard refused the insert. Either way, fail
+            # loudly rather than pretend success.
+            if not self.track_in_graph(track_id):
+                raise TrackNotInGraphError(track_id)
+            raise SectionBoundaryError(
+                f"a section of track {track_id!r} already starts at {int(start_ms)}ms"
+            )
         return {"type": "section", **params["section"]}
 
     def undo(self, record):

--- a/application/annotations/model.py
+++ b/application/annotations/model.py
@@ -13,12 +13,27 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 from application.config import APPLICATION_DIR
-from application.graph_database.connect import execute_query_against_neo4j
 from application.loggers import get_logger
 
 logger = get_logger(__name__)
 
 ANNOTATION_QUERIES_DIR = APPLICATION_DIR / "graph_database" / "queries" / "annotations"
+
+
+class AnnotationWriteError(Exception):
+    """A write that should have persisted an annotation didn't."""
+
+
+class TrackNotInGraphError(AnnotationWriteError):
+    """The target Track id matched nothing — the insert queries MATCH the
+    Track (never MERGE — annotations must not create placeholder Tracks), so
+    a missing track makes the whole write a silent no-op unless we raise."""
+
+    def __init__(self, track_id):
+        self.track_id = track_id
+        super().__init__(
+            f"track {track_id!r} is not in the graph - only crawled tracks are annotatable"
+        )
 
 # Section.kind vocabulary — EDM and song-form both first-class (plan 04 A).
 SECTION_KINDS = (
@@ -43,6 +58,7 @@ DELETE_ANNOTATION_QUERY = _load_query("delete_annotation")
 DELETE_SECTION_QUERY = _load_query("delete_section_and_reopen_previous")
 NUDGE_ANNOTATION_QUERY = _load_query("nudge_annotation")
 NEXT_SECTION_ORDER_QUERY = _load_query("next_section_order")
+TRACK_EXISTS_QUERY = _load_query("track_exists")
 
 
 def _now_iso():
@@ -118,9 +134,15 @@ class Neo4jAnnotationWriter:
         self.database = database
 
     def _execute(self, query, **params):
-        execute_query_against_neo4j(
-            query=query, driver=self.driver, database=self.database, **params
+        """Run a write query; returns the result counters so callers can
+        verify the write actually matched something (a MATCH that finds no
+        rows makes the whole query a no-op WITHOUT raising)."""
+        summary = self.driver.execute_query(query, database_=self.database, **params).summary
+        logger.info(
+            f"Nodes created: {summary.counters.nodes_created}, "
+            f"edges created: {summary.counters.relationships_created}"
         )
+        return summary.counters
 
     def _fetch(self, query, **params):
         records, _, _ = self.driver.execute_query(query, database_=self.database, **params)
@@ -128,17 +150,23 @@ class Neo4jAnnotationWriter:
 
     def add_note(self, track_id, text, at_ms=None):
         params = build_note_params(track_id, text, at_ms=at_ms)
-        self._execute(INSERT_NOTE_QUERY, **params)
+        counters = self._execute(INSERT_NOTE_QUERY, **params)
+        if counters.nodes_created == 0:
+            raise TrackNotInGraphError(track_id)
         return {"type": "note", **params["note"]}
 
     def add_cue(self, track_id, at_ms, label):
         params = build_cue_params(track_id, at_ms, label)
-        self._execute(INSERT_CUE_QUERY, **params)
+        counters = self._execute(INSERT_CUE_QUERY, **params)
+        if counters.nodes_created == 0:
+            raise TrackNotInGraphError(track_id)
         return {"type": "cue", **params["cue"]}
 
     def add_section(self, track_id, order, start_ms, label, kind=None, end_ms=None):
         params = build_section_params(track_id, order, start_ms, label, kind=kind, end_ms=end_ms)
-        self._execute(INSERT_SECTION_QUERY, **params)
+        counters = self._execute(INSERT_SECTION_QUERY, **params)
+        if counters.nodes_created == 0:
+            raise TrackNotInGraphError(track_id)
         return {"type": "section", **params["section"]}
 
     def undo(self, record):
@@ -154,6 +182,12 @@ class Neo4jAnnotationWriter:
     def next_section_order(self, track_id):
         rows = self._fetch(NEXT_SECTION_ORDER_QUERY, track_id=track_id)
         return rows[0]["next_order"] if rows else 0
+
+    def track_in_graph(self, track_id):
+        """True when the Track is in the graph (i.e. annotatable). `listen`
+        checks this on track change to warn BEFORE captures start failing."""
+        rows = self._fetch(TRACK_EXISTS_QUERY, track_id=track_id)
+        return bool(rows and rows[0]["present"])
 
     def search_tracks(self, search_term):
         return self._fetch(FETCH_TRACKS_BY_NAME_QUERY, search_term=search_term)

--- a/application/annotations/model.py
+++ b/application/annotations/model.py
@@ -1,0 +1,166 @@
+"""Annotation model layer (plan 04, phases A-B): Notes, Cues, and Sections
+attached to Tracks.
+
+Split so the interesting parts test offline:
+  - build_*_params are pure (app-side uuid4 ids + UTC created_at timestamps)
+    and define the exact param shapes the Cypher under
+    application/graph_database/queries/annotations/ consumes;
+  - Neo4jAnnotationWriter is the thin execution layer over the bolt driver.
+    It implements the writer protocol PlaybackTracker (listen.py) expects:
+    add_note / add_cue / add_section / undo / nudge / next_section_order.
+"""
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from application.config import APPLICATION_DIR
+from application.graph_database.connect import execute_query_against_neo4j
+from application.loggers import get_logger
+
+logger = get_logger(__name__)
+
+ANNOTATION_QUERIES_DIR = APPLICATION_DIR / "graph_database" / "queries" / "annotations"
+
+# Section.kind vocabulary — EDM and song-form both first-class (plan 04 A).
+SECTION_KINDS = (
+    "intro", "verse", "chorus", "bridge", "buildup", "drop",
+    "breakdown", "interlude", "outro", "custom",
+)
+
+
+def _load_query(name):
+    with open(ANNOTATION_QUERIES_DIR / f"{name}.cypher", "r") as f:
+        return f.read()
+
+
+INSERT_NOTE_QUERY = _load_query("insert_note")
+INSERT_CUE_QUERY = _load_query("insert_cue")
+INSERT_SECTION_QUERY = _load_query("insert_section")
+FETCH_NOTES_QUERY = _load_query("fetch_notes_for_track")
+FETCH_CUES_QUERY = _load_query("fetch_cues_for_track")
+FETCH_SECTIONS_QUERY = _load_query("fetch_sections_for_track")
+FETCH_TRACKS_BY_NAME_QUERY = _load_query("fetch_tracks_by_name")
+DELETE_ANNOTATION_QUERY = _load_query("delete_annotation")
+DELETE_SECTION_QUERY = _load_query("delete_section_and_reopen_previous")
+NUDGE_ANNOTATION_QUERY = _load_query("nudge_annotation")
+NEXT_SECTION_ORDER_QUERY = _load_query("next_section_order")
+
+
+def _now_iso():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def normalize_kind(label):
+    """Derive Section.kind from a freeform label: 'Buildup 2' -> 'buildup',
+    anything outside the vocabulary -> 'custom'."""
+    words = (label or "").strip().lower().split()
+    first = words[0] if words else ""
+    return first if first in SECTION_KINDS else "custom"
+
+
+def build_note_params(track_id, text, at_ms=None):
+    """Param shape for insert_note.cypher. at_ms is optional: set during live
+    capture, null for cold entry."""
+    return {
+        "note": {
+            "track_id": track_id,
+            "id": str(uuid4()),
+            "text": text,
+            "at_ms": None if at_ms is None else int(at_ms),
+            "created_at": _now_iso(),
+        }
+    }
+
+
+def build_cue_params(track_id, at_ms, label):
+    """Param shape for insert_cue.cypher."""
+    return {
+        "cue": {
+            "track_id": track_id,
+            "id": str(uuid4()),
+            "at_ms": int(at_ms),
+            "label": label,
+            "created_at": _now_iso(),
+        }
+    }
+
+
+def build_section_params(track_id, order, start_ms, label, kind=None, end_ms=None):
+    """Param shape for insert_section.cypher. kind derives from the label
+    unless given explicitly (then it must be in the vocabulary); end_ms stays
+    null for an open section (closed by the next boundary or track end)."""
+    if kind is None:
+        kind = normalize_kind(label)
+    elif kind not in SECTION_KINDS:
+        raise ValueError(f"unknown section kind {kind!r}; expected one of {SECTION_KINDS}")
+    return {
+        "section": {
+            "track_id": track_id,
+            "id": str(uuid4()),
+            "order": int(order),
+            "start_ms": int(start_ms),
+            "end_ms": None if end_ms is None else int(end_ms),
+            "label": label,
+            "kind": kind,
+            "created_at": _now_iso(),
+        }
+    }
+
+
+class Neo4jAnnotationWriter:
+    """Writes annotations straight to Neo4j via the bolt driver.
+
+    Each add_* returns a flat record dict ({"type": ..., **params}) that the
+    CLIs keep on their undo stacks and hand back to undo()/nudge().
+    """
+
+    def __init__(self, driver, database="neo4j"):
+        self.driver = driver
+        self.database = database
+
+    def _execute(self, query, **params):
+        execute_query_against_neo4j(
+            query=query, driver=self.driver, database=self.database, **params
+        )
+
+    def _fetch(self, query, **params):
+        records, _, _ = self.driver.execute_query(query, database_=self.database, **params)
+        return [dict(record) for record in records]
+
+    def add_note(self, track_id, text, at_ms=None):
+        params = build_note_params(track_id, text, at_ms=at_ms)
+        self._execute(INSERT_NOTE_QUERY, **params)
+        return {"type": "note", **params["note"]}
+
+    def add_cue(self, track_id, at_ms, label):
+        params = build_cue_params(track_id, at_ms, label)
+        self._execute(INSERT_CUE_QUERY, **params)
+        return {"type": "cue", **params["cue"]}
+
+    def add_section(self, track_id, order, start_ms, label, kind=None, end_ms=None):
+        params = build_section_params(track_id, order, start_ms, label, kind=kind, end_ms=end_ms)
+        self._execute(INSERT_SECTION_QUERY, **params)
+        return {"type": "section", **params["section"]}
+
+    def undo(self, record):
+        if record["type"] == "section":
+            self._execute(DELETE_SECTION_QUERY, section_id=record["id"])
+        else:
+            self._execute(DELETE_ANNOTATION_QUERY, annotation_id=record["id"])
+        logger.info(f'Undid {record["type"]} {record["id"]}')
+
+    def nudge(self, record, at_ms):
+        self._execute(NUDGE_ANNOTATION_QUERY, annotation_id=record["id"], at_ms=int(at_ms))
+
+    def next_section_order(self, track_id):
+        rows = self._fetch(NEXT_SECTION_ORDER_QUERY, track_id=track_id)
+        return rows[0]["next_order"] if rows else 0
+
+    def search_tracks(self, search_term):
+        return self._fetch(FETCH_TRACKS_BY_NAME_QUERY, search_term=search_term)
+
+    def fetch_annotations(self, track_id):
+        return {
+            "notes": self._fetch(FETCH_NOTES_QUERY, track_id=track_id),
+            "cues": self._fetch(FETCH_CUES_QUERY, track_id=track_id),
+            "sections": self._fetch(FETCH_SECTIONS_QUERY, track_id=track_id),
+        }

--- a/application/annotations/model.py
+++ b/application/annotations/model.py
@@ -194,7 +194,13 @@ class Neo4jAnnotationWriter:
         logger.info(f'Undid {record["type"]} {record["id"]}')
 
     def nudge(self, record, at_ms):
-        self._execute(NUDGE_ANNOTATION_QUERY, annotation_id=record["id"], at_ms=int(at_ms))
+        """Move an annotation's position. Returns True when applied; False
+        when the move was rejected because it would break the section-chain
+        invariant (invert a section or cross a neighboring boundary) — the
+        graph is untouched in that case, so callers must not update their
+        local copy either."""
+        rows = self._fetch(NUDGE_ANNOTATION_QUERY, annotation_id=record["id"], at_ms=int(at_ms))
+        return bool(rows and rows[0]["applied"])
 
     def next_section_order(self, track_id):
         rows = self._fetch(NEXT_SECTION_ORDER_QUERY, track_id=track_id)

--- a/application/annotations/timecode.py
+++ b/application/annotations/timecode.py
@@ -1,0 +1,57 @@
+"""Millisecond <-> human timecode helpers for the annotation CLIs.
+
+Pure stdlib, pure functions — unit-testable offline.
+"""
+
+
+def parse_position(text):
+    """Parse a playback position into milliseconds.
+
+    Accepted forms:
+      "2:10"      -> 130000   (M:SS)
+      "2:10.5"    -> 130500   (fractional seconds)
+      "1:02:03"   -> 3723000  (H:MM:SS)
+      "90"        -> 90000    (bare number = seconds)
+      "90.25"     -> 90250
+      "41000ms"   -> 41000    (explicit milliseconds)
+
+    Raises ValueError on anything else.
+    """
+    if text is None:
+        raise ValueError("position is required")
+    cleaned = text.strip().lower()
+    if not cleaned:
+        raise ValueError("position is required")
+
+    if cleaned.endswith("ms"):
+        try:
+            return int(cleaned[:-2].strip())
+        except ValueError:
+            raise ValueError(f"invalid millisecond position: {text!r}")
+
+    parts = cleaned.split(":")
+    if len(parts) > 3:
+        raise ValueError(f"invalid position: {text!r}")
+
+    try:
+        seconds = float(parts[-1])
+        for exponent, part in enumerate(reversed(parts[:-1]), start=1):
+            seconds += int(part) * 60 ** exponent
+    except ValueError:
+        raise ValueError(f"invalid position: {text!r}")
+
+    if seconds < 0:
+        raise ValueError(f"position cannot be negative: {text!r}")
+    return round(seconds * 1000)
+
+
+def format_ms(ms):
+    """Render milliseconds as M:SS, with a .mmm suffix only when sub-second
+    precision is present (nudges make these common)."""
+    if ms is None:
+        return "-:--"
+    ms = int(ms)
+    minutes, remainder = divmod(ms, 60_000)
+    seconds, millis = divmod(remainder, 1000)
+    base = f"{minutes}:{seconds:02d}"
+    return f"{base}.{millis:03d}" if millis else base

--- a/application/annotations/timecode.py
+++ b/application/annotations/timecode.py
@@ -25,9 +25,15 @@ def parse_position(text):
 
     if cleaned.endswith("ms"):
         try:
-            return int(cleaned[:-2].strip())
+            ms = int(cleaned[:-2].strip())
         except ValueError:
             raise ValueError(f"invalid millisecond position: {text!r}")
+        if ms < 0:
+            # Same rule as the colon/seconds path below: playback positions
+            # can't be negative, and a negative ms corrupts sort order and
+            # section chains downstream.
+            raise ValueError(f"position cannot be negative: {text!r}")
+        return ms
 
     parts = cleaned.split(":")
     if len(parts) > 3:

--- a/application/graph_database/queries/annotations/delete_annotation.cypher
+++ b/application/graph_database/queries/annotations/delete_annotation.cypher
@@ -1,0 +1,6 @@
+// Undo for Notes and Cues (Sections use delete_section_and_reopen_previous,
+// which also repairs the NEXT chain's end_ms bookkeeping).
+MATCH (a)
+WHERE a.id = $annotation_id AND (a:Note OR a:Cue)
+DETACH DELETE a
+;

--- a/application/graph_database/queries/annotations/delete_section_and_reopen_previous.cypher
+++ b/application/graph_database/queries/annotations/delete_section_and_reopen_previous.cypher
@@ -1,0 +1,11 @@
+// Undo for Sections: if the previous section's end_ms was closed by this
+// boundary (insert_section sets prev.end_ms = new start_ms), reopen it so the
+// chain returns to its pre-insert state. FOREACH-guard because prev may not
+// exist (undoing the first section) and SET on a null node is an error.
+MATCH (s:Section {id: $section_id})
+OPTIONAL MATCH (prev:Section)-[:NEXT]->(s)
+FOREACH (p IN CASE WHEN prev IS NOT NULL AND prev.end_ms = s.start_ms THEN [prev] ELSE [] END |
+    SET p.end_ms = null
+)
+DETACH DELETE s
+;

--- a/application/graph_database/queries/annotations/delete_section_and_reopen_previous.cypher
+++ b/application/graph_database/queries/annotations/delete_section_and_reopen_previous.cypher
@@ -1,19 +1,28 @@
-// Undo for Sections: if the previous section's end_ms was closed by this
-// boundary (insert_section sets prev.end_ms = new start_ms and leaves
-// prev.end_ms_explicit false), reopen it so the chain returns to its
-// pre-insert state. Value equality alone can't distinguish a chain-derived
-// end from a user-provided end that happens to equal this boundary's start
-// (the natural contiguous case), so the end_ms_explicit provenance flag
-// gates the reopen: explicit ends are NEVER erased. For pre-flag legacy
-// nodes coalesce treats any set end_ms as explicit — the safe direction
-// (keep data rather than null it). FOREACH-guard because prev may not exist
-// (undoing the first section) and SET on a null node is an error.
+// Undo for Sections: restore the chain to its pre-insert state.
+//
+// - If the deleted section sat between two others (a position-aware middle
+//   insert), bridge prev-[:NEXT]->next so the chain stays connected.
+// - If the previous section's end_ms was closed by this boundary
+//   (insert_section sets prev.end_ms = new start_ms and leaves
+//   prev.end_ms_explicit false), re-derive it: back to the successor's start
+//   when one exists, otherwise reopen (null = runs to track end). Value
+//   equality alone can't distinguish a chain-derived end from a user-provided
+//   end that happens to equal this boundary's start (the natural contiguous
+//   case), so the end_ms_explicit provenance flag gates this: explicit ends
+//   are NEVER erased. Pre-flag legacy nodes with a set end_ms are treated as
+//   explicit — the safe direction (keep data rather than null it).
+// FOREACH-guards because prev/next may not exist and SET/MERGE on a null
+// node is an error.
 MATCH (s:Section {id: $section_id})
 OPTIONAL MATCH (prev:Section)-[:NEXT]->(s)
+OPTIONAL MATCH (s)-[:NEXT]->(next:Section)
+FOREACH (_ IN CASE WHEN prev IS NOT NULL AND next IS NOT NULL THEN [1] ELSE [] END |
+    MERGE (prev)-[:NEXT]->(next)
+)
 FOREACH (p IN CASE WHEN prev IS NOT NULL AND prev.end_ms = s.start_ms
                         AND coalesce(prev.end_ms_explicit, prev.end_ms IS NOT NULL) = false
               THEN [prev] ELSE [] END |
-    SET p.end_ms = null
+    SET p.end_ms = CASE WHEN next IS NULL THEN null ELSE next.start_ms END
 )
 DETACH DELETE s
 ;

--- a/application/graph_database/queries/annotations/delete_section_and_reopen_previous.cypher
+++ b/application/graph_database/queries/annotations/delete_section_and_reopen_previous.cypher
@@ -1,10 +1,18 @@
 // Undo for Sections: if the previous section's end_ms was closed by this
-// boundary (insert_section sets prev.end_ms = new start_ms), reopen it so the
-// chain returns to its pre-insert state. FOREACH-guard because prev may not
-// exist (undoing the first section) and SET on a null node is an error.
+// boundary (insert_section sets prev.end_ms = new start_ms and leaves
+// prev.end_ms_explicit false), reopen it so the chain returns to its
+// pre-insert state. Value equality alone can't distinguish a chain-derived
+// end from a user-provided end that happens to equal this boundary's start
+// (the natural contiguous case), so the end_ms_explicit provenance flag
+// gates the reopen: explicit ends are NEVER erased. For pre-flag legacy
+// nodes coalesce treats any set end_ms as explicit — the safe direction
+// (keep data rather than null it). FOREACH-guard because prev may not exist
+// (undoing the first section) and SET on a null node is an error.
 MATCH (s:Section {id: $section_id})
 OPTIONAL MATCH (prev:Section)-[:NEXT]->(s)
-FOREACH (p IN CASE WHEN prev IS NOT NULL AND prev.end_ms = s.start_ms THEN [prev] ELSE [] END |
+FOREACH (p IN CASE WHEN prev IS NOT NULL AND prev.end_ms = s.start_ms
+                        AND coalesce(prev.end_ms_explicit, prev.end_ms IS NOT NULL) = false
+              THEN [prev] ELSE [] END |
     SET p.end_ms = null
 )
 DETACH DELETE s

--- a/application/graph_database/queries/annotations/fetch_cues_for_track.cypher
+++ b/application/graph_database/queries/annotations/fetch_cues_for_track.cypher
@@ -1,0 +1,7 @@
+MATCH (t:Track {id: $track_id})-[:HAS_CUE]->(c:Cue)
+RETURN c.id AS id,
+       c.at_ms AS at_ms,
+       c.label AS label,
+       c.created_at AS created_at
+ORDER BY c.at_ms
+;

--- a/application/graph_database/queries/annotations/fetch_notes_for_track.cypher
+++ b/application/graph_database/queries/annotations/fetch_notes_for_track.cypher
@@ -1,0 +1,7 @@
+MATCH (t:Track {id: $track_id})-[:HAS_NOTE]->(n:Note)
+RETURN n.id AS id,
+       n.text AS text,
+       n.at_ms AS at_ms,
+       n.created_at AS created_at
+ORDER BY n.created_at
+;

--- a/application/graph_database/queries/annotations/fetch_sections_for_track.cypher
+++ b/application/graph_database/queries/annotations/fetch_sections_for_track.cypher
@@ -6,5 +6,8 @@ RETURN s.id AS id,
        s.label AS label,
        s.kind AS kind,
        s.created_at AS created_at
-ORDER BY s.order
+// Chain order is TIME order (NEXT is strictly increasing in start_ms);
+// `order` is only the capture-sequence id, which diverges from time order
+// when a boundary is entered late.
+ORDER BY s.start_ms
 ;

--- a/application/graph_database/queries/annotations/fetch_sections_for_track.cypher
+++ b/application/graph_database/queries/annotations/fetch_sections_for_track.cypher
@@ -1,0 +1,10 @@
+MATCH (t:Track {id: $track_id})-[:HAS_SECTION]->(s:Section)
+RETURN s.id AS id,
+       s.order AS `order`,
+       s.start_ms AS start_ms,
+       s.end_ms AS end_ms,
+       s.label AS label,
+       s.kind AS kind,
+       s.created_at AS created_at
+ORDER BY s.order
+;

--- a/application/graph_database/queries/annotations/fetch_tracks_by_name.cypher
+++ b/application/graph_database/queries/annotations/fetch_tracks_by_name.cypher
@@ -1,0 +1,14 @@
+// Cold-entry track picker for `annotate`: case-insensitive substring search
+// over tracks already in the graph, with enough context to disambiguate.
+MATCH (t:Track)
+WHERE toLower(t.name) CONTAINS toLower($search_term)
+OPTIONAL MATCH (t)<-[:CREATED]-(ar:Artist)
+OPTIONAL MATCH (t)<-[:CONTAINS]-(al:Album)
+RETURN t.id AS id,
+       t.name AS name,
+       t.duration_ms AS duration_ms,
+       collect(DISTINCT ar.name) AS artists,
+       head(collect(DISTINCT al.name)) AS album
+ORDER BY t.name
+LIMIT 25
+;

--- a/application/graph_database/queries/annotations/insert_cue.cypher
+++ b/application/graph_database/queries/annotations/insert_cue.cypher
@@ -1,0 +1,13 @@
+WITH $cue as cue
+
+MATCH (t:Track {id: cue.track_id})
+
+CREATE (c:Cue {
+    id: cue.id,
+    at_ms: cue.at_ms,
+    label: cue.label,
+    created_at: cue.created_at
+})
+
+CREATE (t)-[:HAS_CUE]->(c)
+;

--- a/application/graph_database/queries/annotations/insert_note.cypher
+++ b/application/graph_database/queries/annotations/insert_note.cypher
@@ -1,0 +1,15 @@
+WITH $note as note
+
+MATCH (t:Track {id: note.track_id})
+
+CREATE (n:Note {
+    id: note.id,
+    text: note.text,
+    created_at: note.created_at
+})
+// Optional playback position: present for live capture (`listen`), null for
+// cold entry — setting a property to null is a no-op, so it simply isn't stored.
+SET n.at_ms = note.at_ms
+
+CREATE (t)-[:HAS_NOTE]->(n)
+;

--- a/application/graph_database/queries/annotations/insert_section.cypher
+++ b/application/graph_database/queries/annotations/insert_section.cypher
@@ -1,0 +1,33 @@
+WITH $section as section
+
+MATCH (t:Track {id: section.track_id})
+
+CREATE (s:Section {
+    id: section.id,
+    order: section.order,
+    start_ms: section.start_ms,
+    label: section.label,
+    kind: section.kind,
+    created_at: section.created_at
+})
+// end_ms may be null: an open section runs until the next boundary (which
+// closes it below on its own insert) or the track end.
+SET s.end_ms = section.end_ms
+
+CREATE (t)-[:HAS_SECTION]->(s)
+
+// Chain NEXT from the immediately-preceding section of the same track (the
+// highest order below this one) and close its open end at this boundary.
+// Independent CALL subquery so a first section (no predecessor) doesn't drop
+// the row.
+WITH t, s
+CALL (t, s) {
+    MATCH (t)-[:HAS_SECTION]->(prev:Section)
+    WHERE prev.order < s.order
+    WITH prev, s
+    ORDER BY prev.order DESC
+    LIMIT 1
+    MERGE (prev)-[:NEXT]->(s)
+    SET prev.end_ms = coalesce(prev.end_ms, s.start_ms)
+}
+;

--- a/application/graph_database/queries/annotations/insert_section.cypher
+++ b/application/graph_database/queries/annotations/insert_section.cypher
@@ -13,6 +13,11 @@ CREATE (s:Section {
 // end_ms may be null: an open section runs until the next boundary (which
 // closes it below on its own insert) or the track end.
 SET s.end_ms = section.end_ms
+// Provenance: true only when the caller supplied end_ms explicitly.
+// Chain-derived ends (set by a later boundary's insert) keep this false, so
+// undo/nudge can re-derive or reopen them WITHOUT ever destroying a
+// user-provided end that merely coincides with the next boundary's start.
+SET s.end_ms_explicit = section.end_ms IS NOT NULL
 
 CREATE (t)-[:HAS_SECTION]->(s)
 

--- a/application/graph_database/queries/annotations/insert_section.cypher
+++ b/application/graph_database/queries/annotations/insert_section.cypher
@@ -2,6 +2,15 @@ WITH $section as section
 
 MATCH (t:Track {id: section.track_id})
 
+// Chain invariant: NEXT is strictly increasing in start_ms, so two sections
+// of one track can never share a boundary. A duplicate start makes the whole
+// query match nothing (zero writes) — the writer turns the zero-created
+// counter into a loud SectionBoundaryError instead of corrupting the chain.
+WHERE NOT EXISTS {
+    MATCH (t)-[:HAS_SECTION]->(dup:Section)
+    WHERE dup.start_ms = section.start_ms
+}
+
 CREATE (s:Section {
     id: section.id,
     order: section.order,
@@ -21,18 +30,44 @@ SET s.end_ms_explicit = section.end_ms IS NOT NULL
 
 CREATE (t)-[:HAS_SECTION]->(s)
 
-// Chain NEXT from the immediately-preceding section of the same track (the
-// highest order below this one) and close its open end at this boundary.
-// Independent CALL subquery so a first section (no predecessor) doesn't drop
-// the row.
+// The chain is ordered by TIME (start_ms), not by insertion order: `order` is
+// only a capture-sequence id for undo bookkeeping. A boundary remembered late
+// ("intro at 0:00" entered after "drop at 2:10") slots into place instead of
+// chaining backwards in time. Independent CALL subqueries so a missing
+// predecessor/successor doesn't drop the row.
+
+// Predecessor = latest section strictly before the new boundary. Its NEXT
+// edge (if any) now belongs to the new section, and its chain-derived end
+// closes at this boundary; explicit ends are never overwritten.
 WITH t, s
 CALL (t, s) {
     MATCH (t)-[:HAS_SECTION]->(prev:Section)
-    WHERE prev.order < s.order
+    WHERE prev <> s AND prev.start_ms < s.start_ms
     WITH prev, s
-    ORDER BY prev.order DESC
+    ORDER BY prev.start_ms DESC
     LIMIT 1
+    OPTIONAL MATCH (prev)-[old:NEXT]->(:Section)
+    DELETE old
     MERGE (prev)-[:NEXT]->(s)
-    SET prev.end_ms = coalesce(prev.end_ms, s.start_ms)
+    FOREACH (p IN CASE WHEN coalesce(prev.end_ms_explicit, prev.end_ms IS NOT NULL) = false
+                  THEN [prev] ELSE [] END |
+        SET p.end_ms = s.start_ms
+    )
+}
+
+// Successor = earliest section strictly after the new boundary: the new
+// section chains into it and (unless explicitly ended) closes there, keeping
+// end_ms >= start_ms by construction.
+WITH t, s
+CALL (t, s) {
+    MATCH (t)-[:HAS_SECTION]->(next:Section)
+    WHERE next <> s AND next.start_ms > s.start_ms
+    WITH next, s
+    ORDER BY next.start_ms ASC
+    LIMIT 1
+    MERGE (s)-[:NEXT]->(next)
+    FOREACH (x IN CASE WHEN coalesce(s.end_ms_explicit, false) = false THEN [s] ELSE [] END |
+        SET x.end_ms = next.start_ms
+    )
 }
 ;

--- a/application/graph_database/queries/annotations/next_section_order.cypher
+++ b/application/graph_database/queries/annotations/next_section_order.cypher
@@ -1,0 +1,6 @@
+// max(order)+1 rather than count(*): deleted sections must not make orders
+// collide with survivors.
+MATCH (t:Track {id: $track_id})
+OPTIONAL MATCH (t)-[:HAS_SECTION]->(s:Section)
+RETURN coalesce(max(s.order), -1) + 1 AS next_order
+;

--- a/application/graph_database/queries/annotations/nudge_annotation.cypher
+++ b/application/graph_database/queries/annotations/nudge_annotation.cypher
@@ -11,7 +11,12 @@ FOREACH (n IN CASE WHEN a:Note AND a.at_ms IS NOT NULL THEN [a] ELSE [] END |
 FOREACH (c IN CASE WHEN a:Cue THEN [a] ELSE [] END |
     SET c.at_ms = $at_ms
 )
-FOREACH (p IN CASE WHEN prev IS NOT NULL AND a:Section AND prev.end_ms = a.start_ms THEN [prev] ELSE [] END |
+// Only chain-derived previous ends move with the boundary: an explicit
+// prev.end_ms that happens to equal this start (contiguous entry) must not
+// be dragged. Legacy nodes without the flag are treated as explicit (safe).
+FOREACH (p IN CASE WHEN prev IS NOT NULL AND a:Section AND prev.end_ms = a.start_ms
+                        AND coalesce(prev.end_ms_explicit, prev.end_ms IS NOT NULL) = false
+              THEN [prev] ELSE [] END |
     SET p.end_ms = $at_ms
 )
 FOREACH (s IN CASE WHEN a:Section THEN [a] ELSE [] END |

--- a/application/graph_database/queries/annotations/nudge_annotation.cypher
+++ b/application/graph_database/queries/annotations/nudge_annotation.cypher
@@ -1,0 +1,20 @@
+// Fine-tune a captured timestamp (the +/- 500ms nudge keys in `listen`).
+// FOREACH order is load-bearing for Sections: the previous section's chained
+// end_ms must be re-pointed while it still equals the OLD start_ms, before the
+// new start_ms is written. Notes are only nudged if they carry a position.
+MATCH (a)
+WHERE a.id = $annotation_id AND (a:Note OR a:Cue OR a:Section)
+OPTIONAL MATCH (prev:Section)-[:NEXT]->(a)
+FOREACH (n IN CASE WHEN a:Note AND a.at_ms IS NOT NULL THEN [a] ELSE [] END |
+    SET n.at_ms = $at_ms
+)
+FOREACH (c IN CASE WHEN a:Cue THEN [a] ELSE [] END |
+    SET c.at_ms = $at_ms
+)
+FOREACH (p IN CASE WHEN prev IS NOT NULL AND a:Section AND prev.end_ms = a.start_ms THEN [prev] ELSE [] END |
+    SET p.end_ms = $at_ms
+)
+FOREACH (s IN CASE WHEN a:Section THEN [a] ELSE [] END |
+    SET s.start_ms = $at_ms
+)
+;

--- a/application/graph_database/queries/annotations/nudge_annotation.cypher
+++ b/application/graph_database/queries/annotations/nudge_annotation.cypher
@@ -1,25 +1,44 @@
 // Fine-tune a captured timestamp (the +/- 500ms nudge keys in `listen`).
+//
+// Section moves are validated against the chain invariant BEFORE anything is
+// written; an out-of-bounds move is rejected wholesale (applied = false) so
+// the caller tells the user instead of corrupting the chain:
+//   - strictly after the previous section's start (dragging the chained
+//     prev.end_ms to or below prev.start_ms would invert the predecessor);
+//   - strictly before the next section's start (NEXT is strictly increasing
+//     in start_ms);
+//   - at most the section's own end_ms (never end_ms < start_ms).
+// Notes and Cues have no chain constraints (callers floor them at 0).
+//
 // FOREACH order is load-bearing for Sections: the previous section's chained
 // end_ms must be re-pointed while it still equals the OLD start_ms, before the
 // new start_ms is written. Notes are only nudged if they carry a position.
 MATCH (a)
 WHERE a.id = $annotation_id AND (a:Note OR a:Cue OR a:Section)
 OPTIONAL MATCH (prev:Section)-[:NEXT]->(a)
-FOREACH (n IN CASE WHEN a:Note AND a.at_ms IS NOT NULL THEN [a] ELSE [] END |
+OPTIONAL MATCH (a)-[:NEXT]->(next:Section)
+WITH a, prev, next,
+     ((NOT a:Section) OR (
+         (prev IS NULL OR $at_ms > prev.start_ms)
+         AND (next IS NULL OR $at_ms < next.start_ms)
+         AND (a.end_ms IS NULL OR $at_ms <= a.end_ms)
+     )) AS applied
+FOREACH (n IN CASE WHEN applied AND a:Note AND a.at_ms IS NOT NULL THEN [a] ELSE [] END |
     SET n.at_ms = $at_ms
 )
-FOREACH (c IN CASE WHEN a:Cue THEN [a] ELSE [] END |
+FOREACH (c IN CASE WHEN applied AND a:Cue THEN [a] ELSE [] END |
     SET c.at_ms = $at_ms
 )
 // Only chain-derived previous ends move with the boundary: an explicit
 // prev.end_ms that happens to equal this start (contiguous entry) must not
 // be dragged. Legacy nodes without the flag are treated as explicit (safe).
-FOREACH (p IN CASE WHEN prev IS NOT NULL AND a:Section AND prev.end_ms = a.start_ms
+FOREACH (p IN CASE WHEN applied AND prev IS NOT NULL AND a:Section AND prev.end_ms = a.start_ms
                         AND coalesce(prev.end_ms_explicit, prev.end_ms IS NOT NULL) = false
               THEN [prev] ELSE [] END |
     SET p.end_ms = $at_ms
 )
-FOREACH (s IN CASE WHEN a:Section THEN [a] ELSE [] END |
+FOREACH (s IN CASE WHEN applied AND a:Section THEN [a] ELSE [] END |
     SET s.start_ms = $at_ms
 )
+RETURN applied
 ;

--- a/application/graph_database/queries/annotations/track_exists.cypher
+++ b/application/graph_database/queries/annotations/track_exists.cypher
@@ -1,0 +1,9 @@
+// Graph-membership probe for the live-capture UI (`listen`): unlike
+// `annotate`, which only offers tracks already in the graph, `listen` takes
+// its track id straight from /v1/me/player — the track may not be crawled
+// yet, and every insert query MATCHes the Track (never MERGE: annotations
+// must not create placeholder Track nodes). count() aggregates over zero
+// rows, so this always returns exactly one row.
+MATCH (t:Track {id: $track_id})
+RETURN count(t) > 0 AS present
+;

--- a/application/graph_database/queries/apply_uniqueness_constraints_to_nodes.cypher
+++ b/application/graph_database/queries/apply_uniqueness_constraints_to_nodes.cypher
@@ -14,3 +14,18 @@ REQUIRE track.id IS UNIQUE;
 CREATE CONSTRAINT song_id_uniqueness IF NOT EXISTS
 FOR (song:Song)
 REQUIRE song.id IS UNIQUE;
+
+// --- 04 annotations & DJ sets (phases A-B): Note / Cue / Section ---
+// Annotation ids are app-side uuid4 (application/annotations/model.py).
+
+CREATE CONSTRAINT note_id_uniqueness IF NOT EXISTS
+FOR (note:Note)
+REQUIRE note.id IS UNIQUE;
+
+CREATE CONSTRAINT cue_id_uniqueness IF NOT EXISTS
+FOR (cue:Cue)
+REQUIRE cue.id IS UNIQUE;
+
+CREATE CONSTRAINT section_id_uniqueness IF NOT EXISTS
+FOR (section:Section)
+REQUIRE section.id IS UNIQUE;

--- a/mock_spotify/app.py
+++ b/mock_spotify/app.py
@@ -5,6 +5,7 @@ Endpoints (api.spotify.com facade):
   GET  /v1/me/tracks?offset=&limit=     paginated saved tracks (self-referential next)
   GET  /v1/{tracks,albums,artists}/{id} single resource (404 if unknown)
   GET  /v1/{tracks,albums,artists}?ids= batch (null for unknown ids)
+  GET  /v1/me/player                    playback state (204 if none; see catalog player_*)
 Auth (accounts.spotify.com facade):
   POST /api/token                       fake token (authorization_code / refresh_token)
   GET  /authorize                       redirect to the callback with a fake code
@@ -119,18 +120,33 @@ class ControlConfigResource:
         for key in INJECTION:
             if key in cfg:
                 INJECTION[key] = cfg[key]
-        resp.media = dict(INJECTION)
+        player = catalog.configure_player(cfg)  # player_* keys (plan 04 phase B)
+        resp.media = {**INJECTION, **player}
 
 
 class ControlResetResource:
     def on_post(self, req, resp):
         INJECTION.update(_default_injection())
+        catalog.reset_player()
         resp.media = dict(INJECTION)
 
 
 class HealthResource:
     def on_get(self, req, resp):
         resp.media = {"status": "ok"}
+
+
+class PlayerResource:
+    """GET /v1/me/player (plan 04 phase B): currently-playing state, scripted
+    via /_control/config player_* keys. 204 like the real API when there's no
+    active device (player_track_id: null)."""
+
+    def on_get(self, req, resp):
+        state = catalog.player_state()
+        if state is None:
+            resp.status = falcon.HTTP_204
+            return
+        resp.media = state
 
 
 def create_app():
@@ -144,6 +160,7 @@ def create_app():
     app.add_route("/_control/config", ControlConfigResource())
     app.add_route("/_control/reset", ControlResetResource())
     app.add_route("/_control/health", HealthResource())
+    app.add_route("/v1/me/player", PlayerResource())
     return app
 
 

--- a/mock_spotify/catalog.py
+++ b/mock_spotify/catalog.py
@@ -153,3 +153,80 @@ def liked_songs_page(offset, limit):
         "next": next_url,
         "total": N_TRACKS,
     }
+
+
+###
+# Player state (GET /v1/me/player) — plan 04 phase B live-capture testing.
+# Driven via POST /_control/config with player_* keys (app.py forwards them):
+#   {"player_track_id": "trk000003", "player_progress_ms": 41000,
+#    "player_is_playing": true, "player_advance": true}
+# With player_advance, progress advances with wall-clock time from the moment
+# of configuration — computed functionally from the elapsed time (no ticking
+# state), flowing across track boundaries like an album playing through.
+# player_track_id: null => no active device => 204.
+###
+import time  # noqa: E402  (appended section per plan 04; stdlib, safe mid-file)
+
+_PLAYER_DEFAULTS = {
+    "track_id": "trk000000",
+    "progress_ms": 0,
+    "is_playing": True,
+    "advance": False,
+}
+_PLAYER = dict(_PLAYER_DEFAULTS)
+_PLAYER["configured_at"] = time.time()
+
+_PLAYER_CONTROL_KEYS = {
+    "player_track_id": "track_id",
+    "player_progress_ms": "progress_ms",
+    "player_is_playing": "is_playing",
+    "player_advance": "advance",
+}
+
+
+def configure_player(cfg):
+    """Apply player_* keys from a /_control/config payload; ignore the rest.
+    Any accepted key re-anchors the wall-clock advance origin."""
+    touched = False
+    for control_key, state_key in _PLAYER_CONTROL_KEYS.items():
+        if control_key in cfg:
+            _PLAYER[state_key] = cfg[control_key]
+            touched = True
+    if touched:
+        _PLAYER["configured_at"] = time.time()
+    return {f"player_{k}": _PLAYER[k] for k in _PLAYER_DEFAULTS}
+
+
+def reset_player():
+    """Back to defaults (called by POST /_control/reset)."""
+    _PLAYER.update(_PLAYER_DEFAULTS)
+    _PLAYER["configured_at"] = time.time()
+
+
+def player_state():
+    """The GET /v1/me/player payload, or None (=> 204, no active device)."""
+    track_id = _PLAYER["track_id"]
+    n = _n("trk", track_id) if track_id else None
+    if n is None or not (0 <= n < N_TRACKS):
+        return None
+
+    progress = int(_PLAYER["progress_ms"])
+    if _PLAYER["advance"] and _PLAYER["is_playing"]:
+        progress += int((time.time() - _PLAYER["configured_at"]) * 1000)
+
+    # Flow across track boundaries like an album playing through.
+    current = track(n)
+    while progress >= current["duration_ms"] and n + 1 < N_TRACKS:
+        progress -= current["duration_ms"]
+        n += 1
+        current = track(n)
+    progress = min(progress, current["duration_ms"])
+
+    return {
+        "device": {"id": "mock-device", "is_active": True, "name": "Mock Device", "type": "Computer"},
+        "timestamp": int(time.time() * 1000),
+        "is_playing": bool(_PLAYER["is_playing"]),
+        "progress_ms": progress,
+        "currently_playing_type": "track",
+        "item": current,
+    }

--- a/tests/test_annotations_annotate.py
+++ b/tests/test_annotations_annotate.py
@@ -1,0 +1,153 @@
+"""Offline tests for the cold-entry annotate CLI flow (plan 04 T2): scripted
+input/output against a fake writer — no TTY, no services."""
+import pytest
+
+from application.annotations import annotate
+from application.annotations import model
+
+
+class FakeWriter:
+    """In-memory stand-in for Neo4jAnnotationWriter; reuses the real param
+    builders so records have the production shape."""
+
+    def __init__(self, tracks=None):
+        self.tracks = tracks or []
+        self.records = []
+        self.undone = []
+
+    def search_tracks(self, search_term):
+        return [t for t in self.tracks if search_term.lower() in t["name"].lower()]
+
+    def add_note(self, track_id, text, at_ms=None):
+        record = {"type": "note", **model.build_note_params(track_id, text, at_ms=at_ms)["note"]}
+        self.records.append(record)
+        return record
+
+    def add_cue(self, track_id, at_ms, label):
+        record = {"type": "cue", **model.build_cue_params(track_id, at_ms, label)["cue"]}
+        self.records.append(record)
+        return record
+
+    def add_section(self, track_id, order, start_ms, label, kind=None, end_ms=None):
+        record = {
+            "type": "section",
+            **model.build_section_params(track_id, order, start_ms, label, kind=kind, end_ms=end_ms)["section"],
+        }
+        self.records.append(record)
+        return record
+
+    def undo(self, record):
+        self.undone.append(record)
+        self.records.remove(record)
+
+    def next_section_order(self, track_id):
+        orders = [r["order"] for r in self.records if r["type"] == "section" and r["track_id"] == track_id]
+        return max(orders, default=-1) + 1
+
+    def fetch_annotations(self, track_id):
+        mine = [r for r in self.records if r["track_id"] == track_id]
+        return {
+            "notes": [r for r in mine if r["type"] == "note"],
+            "cues": [r for r in mine if r["type"] == "cue"],
+            "sections": [r for r in mine if r["type"] == "section"],
+        }
+
+
+def _track(track_id="trk1", name="Strobe", album="Album", artists=("deadmau5",)):
+    return {"id": track_id, "name": name, "duration_ms": 634000, "album": album, "artists": list(artists)}
+
+
+def _scripted(lines):
+    """An input() double fed from a list; raises if the script runs dry."""
+    iterator = iter(lines)
+    return lambda _prompt="": next(iterator)
+
+
+@pytest.fixture
+def out():
+    lines = []
+
+    def _out(message=""):
+        lines.append(str(message))
+
+    _out.lines = lines
+    return _out
+
+
+def test_pick_track_single_match_returns_immediately(out):
+    writer = FakeWriter(tracks=[_track()])
+    picked = annotate.pick_track(writer, "strobe", in_=_scripted([]), out=out)
+    assert picked["id"] == "trk1"
+
+
+def test_pick_track_multiple_matches_prompts_for_choice(out):
+    writer = FakeWriter(tracks=[_track("trk1", "Strobe"), _track("trk2", "Strobe (Club Edit)")])
+    picked = annotate.pick_track(writer, "strobe", in_=_scripted(["banana", "1"]), out=out)
+    assert picked["id"] == "trk2"
+    assert any("invalid" in line for line in out.lines)
+
+
+def test_pick_track_no_match_returns_none(out):
+    assert annotate.pick_track(FakeWriter(), "ghost", in_=_scripted([]), out=out) is None
+
+
+def test_loop_note_cue_section_then_quit(out):
+    writer = FakeWriter(tracks=[_track()])
+    session = annotate.run_annotation_loop(
+        writer,
+        _track(),
+        in_=_scripted([
+            "n", "that switch-up",         # note
+            "c", "2:10", "the drop",       # cue at 130000
+            "s", "0:00", "intro",          # section 0
+            "s", "1:04", "buildup 1",      # section 1 (order chained)
+            "q",
+        ]),
+        out=out,
+    )
+    assert [r["type"] for r in session] == ["note", "cue", "section", "section"]
+    cue = session[1]
+    assert cue["at_ms"] == 130000 and cue["label"] == "the drop"
+    sections = [r for r in session if r["type"] == "section"]
+    assert [s["order"] for s in sections] == [0, 1]
+    assert sections[1]["kind"] == "buildup"
+
+
+def test_loop_undo_removes_last_entry(out):
+    writer = FakeWriter(tracks=[_track()])
+    session = annotate.run_annotation_loop(
+        writer,
+        _track(),
+        in_=_scripted(["n", "keep me", "n", "typo", "u", "q"]),
+        out=out,
+    )
+    assert len(session) == 1 and session[0]["text"] == "keep me"
+    assert len(writer.undone) == 1 and writer.undone[0]["text"] == "typo"
+
+
+def test_loop_rejects_bad_position_then_accepts(out):
+    writer = FakeWriter(tracks=[_track()])
+    session = annotate.run_annotation_loop(
+        writer,
+        _track(),
+        in_=_scripted(["c", "nonsense", "1:30", "hit", "q"]),
+        out=out,
+    )
+    assert session[0]["at_ms"] == 90000
+
+
+def test_loop_blank_position_cancels(out):
+    writer = FakeWriter(tracks=[_track()])
+    session = annotate.run_annotation_loop(
+        writer, _track(), in_=_scripted(["c", "", "q"]), out=out,
+    )
+    assert session == [] and writer.records == []
+
+
+def test_loop_empty_note_discarded_and_undo_on_empty_session(out):
+    writer = FakeWriter(tracks=[_track()])
+    session = annotate.run_annotation_loop(
+        writer, _track(), in_=_scripted(["n", "   ", "u", "q"]), out=out,
+    )
+    assert session == [] and writer.records == []
+    assert any("nothing to undo" in line for line in out.lines)

--- a/tests/test_annotations_cypher.py
+++ b/tests/test_annotations_cypher.py
@@ -225,10 +225,47 @@ def test_nudge_cue_moves_at_ms(writer):
 def test_nudge_section_moves_start_and_chained_previous_end(writer):
     writer.add_section(TRACK_ID, 0, 0, "intro")
     boundary = writer.add_section(TRACK_ID, 1, 64000, "buildup 1")
-    writer.nudge(boundary, 63500)
+    assert writer.nudge(boundary, 63500) is True
     sections = writer.fetch_annotations(TRACK_ID)["sections"]
     assert sections[1]["start_ms"] == 63500
     assert sections[0]["end_ms"] == 63500  # the chained boundary moved with it
+
+
+def test_nudge_section_below_previous_start_is_rejected(writer):
+    """The verifier's reproduction: A at 9800, B at 10000 (A.end chained to
+    10000). One '-' press asks for 9500, which would invert A
+    (end 9500 < start 9800) and start B before A. Rejected wholesale."""
+    writer.add_section(TRACK_ID, 0, 9800, "intro")
+    boundary = writer.add_section(TRACK_ID, 1, 10000, "buildup")
+    assert writer.nudge(boundary, 9500) is False
+    sections = writer.fetch_annotations(TRACK_ID)["sections"]
+    assert [(s["label"], s["start_ms"], s["end_ms"]) for s in sections] == [
+        ("intro", 9800, 10000),  # NOT inverted
+        ("buildup", 10000, None),  # NOT moved
+    ]
+    # equal start would also violate strictly-increasing starts
+    assert writer.nudge(boundary, 9800) is False
+
+
+def test_nudge_section_across_next_boundary_is_rejected(writer):
+    writer.add_section(TRACK_ID, 0, 0, "intro")
+    middle = writer.add_section(TRACK_ID, 1, 64000, "buildup 1")
+    writer.add_section(TRACK_ID, 2, 130000, "drop 1")
+    assert writer.nudge(middle, 130000) is False  # collides with drop's start
+    assert writer.nudge(middle, 130500) is False  # would invert buildup (end 130000)
+    sections = writer.fetch_annotations(TRACK_ID)["sections"]
+    assert [(s["label"], s["start_ms"], s["end_ms"]) for s in sections] == [
+        ("intro", 0, 64000),
+        ("buildup 1", 64000, 130000),
+        ("drop 1", 130000, None),
+    ]
+    # in-bounds moves still work in both directions at the boundary
+    assert writer.nudge(middle, 64500) is True
+    assert writer.nudge(middle, 63500) is True
+    sections = writer.fetch_annotations(TRACK_ID)["sections"]
+    assert sections[1]["start_ms"] == 63500
+    assert sections[0]["end_ms"] == 63500
+    assert all(s["end_ms"] is None or s["end_ms"] >= s["start_ms"] for s in sections)
 
 
 def test_next_section_order_uses_max_not_count(writer):

--- a/tests/test_annotations_cypher.py
+++ b/tests/test_annotations_cypher.py
@@ -3,9 +3,10 @@ Neo4j — the neo4j_driver fixture skips the module when the database isn't
 reachable. Distinctive CYTESTANN uris/ids keep cleanup surgical."""
 import pytest
 
-from application.annotations.model import Neo4jAnnotationWriter
+from application.annotations.model import Neo4jAnnotationWriter, TrackNotInGraphError
 
 TRACK_ID = "CYTESTANN1"
+MISSING_TRACK_ID = "CYTESTANN_NOT_CRAWLED"
 
 
 @pytest.fixture(autouse=True)
@@ -96,6 +97,34 @@ def test_undo_section_reopens_previous_end(writer):
     sections = writer.fetch_annotations(TRACK_ID)["sections"]
     assert len(sections) == 1
     assert sections[0]["end_ms"] is None  # reopened: runs to track end again
+
+
+def test_writes_against_a_track_missing_from_the_graph_raise(writer, neo4j_driver):
+    """The insert Cypher MATCHes the Track (no MERGE, no placeholders): when
+    the track isn't in the graph the query is a silent no-op at the database
+    level, so the writer MUST turn the zero-match into a loud error instead of
+    reporting success (a whole live-listening session was silently lost)."""
+    with pytest.raises(TrackNotInGraphError):
+        writer.add_note(MISSING_TRACK_ID, "lost thought", at_ms=130000)
+    with pytest.raises(TrackNotInGraphError):
+        writer.add_cue(MISSING_TRACK_ID, 41000, "the drop")
+    with pytest.raises(TrackNotInGraphError):
+        writer.add_section(MISSING_TRACK_ID, 0, 0, "intro")
+    # no placeholder Track and no orphan annotation nodes were created
+    records, _, _ = neo4j_driver.execute_query(
+        "MATCH (t:Track {id: $track_id}) RETURN count(t) AS tracks", track_id=MISSING_TRACK_ID
+    )
+    assert records[0]["tracks"] == 0
+    records, _, _ = neo4j_driver.execute_query(
+        "MATCH (a) WHERE (a:Note OR a:Cue OR a:Section) AND NOT (a)<-[]-(:Track) "
+        "RETURN count(a) AS orphans"
+    )
+    assert records[0]["orphans"] == 0
+
+
+def test_track_in_graph_probe(writer):
+    assert writer.track_in_graph(TRACK_ID) is True
+    assert writer.track_in_graph(MISSING_TRACK_ID) is False
 
 
 def test_nudge_cue_moves_at_ms(writer):

--- a/tests/test_annotations_cypher.py
+++ b/tests/test_annotations_cypher.py
@@ -99,6 +99,29 @@ def test_undo_section_reopens_previous_end(writer):
     assert sections[0]["end_ms"] is None  # reopened: runs to track end again
 
 
+def test_undo_contiguous_boundary_preserves_explicit_previous_end(writer):
+    """The natural contiguous case: the next section starts exactly at the
+    explicitly-entered end. Undoing that boundary must NOT erase the
+    user-provided end (only chain-derived ends reopen)."""
+    writer.add_section(TRACK_ID, 0, 0, "intro", end_ms=30000)
+    verse = writer.add_section(TRACK_ID, 1, 30000, "verse")
+    writer.undo(verse)
+    sections = writer.fetch_annotations(TRACK_ID)["sections"]
+    assert len(sections) == 1
+    assert sections[0]["end_ms"] == 30000  # explicit end survives the undo
+
+
+def test_nudge_contiguous_boundary_preserves_explicit_previous_end(writer):
+    """Same conflation on the nudge path: moving a boundary must not drag an
+    explicit previous end that merely coincides with the old start."""
+    writer.add_section(TRACK_ID, 0, 0, "intro", end_ms=30000)
+    verse = writer.add_section(TRACK_ID, 1, 30000, "verse")
+    writer.nudge(verse, 30500)
+    sections = writer.fetch_annotations(TRACK_ID)["sections"]
+    assert sections[1]["start_ms"] == 30500
+    assert sections[0]["end_ms"] == 30000  # explicit end did not move
+
+
 def test_writes_against_a_track_missing_from_the_graph_raise(writer, neo4j_driver):
     """The insert Cypher MATCHes the Track (no MERGE, no placeholders): when
     the track isn't in the graph the query is a silent no-op at the database

--- a/tests/test_annotations_cypher.py
+++ b/tests/test_annotations_cypher.py
@@ -1,0 +1,140 @@
+"""Round-trip tests for the annotation Cypher (plan 04 T1) against a real
+Neo4j — the neo4j_driver fixture skips the module when the database isn't
+reachable. Distinctive CYTESTANN uris/ids keep cleanup surgical."""
+import pytest
+
+from application.annotations.model import Neo4jAnnotationWriter
+
+TRACK_ID = "CYTESTANN1"
+
+
+@pytest.fixture(autouse=True)
+def _cytest_track(neo4j_driver):
+    """A throwaway Track to annotate; purge it AND its annotations around each
+    test (annotations hang off the track, so follow the rels to find them)."""
+    purge = (
+        "MATCH (t:Track) WHERE t.uri CONTAINS 'CYTESTANN' "
+        "OPTIONAL MATCH (t)-[:HAS_NOTE|HAS_CUE|HAS_SECTION]->(a) "
+        "DETACH DELETE t, a"
+    )
+    neo4j_driver.execute_query(purge)
+    neo4j_driver.execute_query(
+        "MERGE (t:Track {uri: 'spotify:track:CYTESTANN1'}) "
+        "SET t.id = $track_id, t.name = 'CYTESTANN Strobe', t.duration_ms = 634000",
+        track_id=TRACK_ID,
+    )
+    yield
+    neo4j_driver.execute_query(purge)
+
+
+@pytest.fixture
+def writer(neo4j_driver):
+    return Neo4jAnnotationWriter(neo4j_driver)
+
+
+def test_uniqueness_constraints_apply_for_annotation_labels(neo4j_driver):
+    from application.graph_database.initialize_database_environment import (
+        apply_uniqueness_constraints,
+    )
+    apply_uniqueness_constraints(neo4j_driver)
+    records, _, _ = neo4j_driver.execute_query("SHOW CONSTRAINTS YIELD name RETURN name")
+    names = {record["name"] for record in records}
+    assert {"note_id_uniqueness", "cue_id_uniqueness", "section_id_uniqueness"} <= names
+
+
+def test_note_and_cue_round_trip(writer):
+    note = writer.add_note(TRACK_ID, "that switch-up", at_ms=130000)
+    cue = writer.add_cue(TRACK_ID, 41000, "the drop")
+    annotations = writer.fetch_annotations(TRACK_ID)
+    assert [n["text"] for n in annotations["notes"]] == ["that switch-up"]
+    assert annotations["notes"][0]["at_ms"] == 130000
+    assert annotations["cues"][0]["id"] == cue["id"]
+    assert annotations["cues"][0]["at_ms"] == 41000
+    # undo removes them again
+    writer.undo(note)
+    writer.undo(cue)
+    annotations = writer.fetch_annotations(TRACK_ID)
+    assert annotations["notes"] == [] and annotations["cues"] == []
+
+
+def test_cold_entry_note_has_no_position(writer):
+    writer.add_note(TRACK_ID, "just a thought")
+    note = writer.fetch_annotations(TRACK_ID)["notes"][0]
+    assert note["at_ms"] is None
+
+
+def test_sections_chain_next_and_close_open_ends(writer, neo4j_driver):
+    writer.add_section(TRACK_ID, 0, 0, "intro")
+    writer.add_section(TRACK_ID, 1, 64000, "buildup 1")
+    writer.add_section(TRACK_ID, 2, 130000, "drop 1")
+
+    sections = writer.fetch_annotations(TRACK_ID)["sections"]
+    assert [s["order"] for s in sections] == [0, 1, 2]
+    assert [s["kind"] for s in sections] == ["intro", "buildup", "drop"]
+    # each boundary closed its predecessor; the last stays open (track end)
+    assert [s["end_ms"] for s in sections] == [64000, 130000, None]
+
+    records, _, _ = neo4j_driver.execute_query(
+        "MATCH (t:Track {id: $track_id})-[:HAS_SECTION]->(a:Section)-[:NEXT]->(b:Section) "
+        "RETURN a.order AS a, b.order AS b ORDER BY a.order",
+        track_id=TRACK_ID,
+    )
+    assert [(record["a"], record["b"]) for record in records] == [(0, 1), (1, 2)]
+
+
+def test_explicit_end_ms_is_not_overwritten_by_next_boundary(writer):
+    writer.add_section(TRACK_ID, 0, 0, "intro", end_ms=30000)  # explicitly closed early
+    writer.add_section(TRACK_ID, 1, 64000, "buildup 1")
+    sections = writer.fetch_annotations(TRACK_ID)["sections"]
+    assert sections[0]["end_ms"] == 30000  # coalesce keeps the explicit value
+
+
+def test_undo_section_reopens_previous_end(writer):
+    writer.add_section(TRACK_ID, 0, 0, "intro")
+    boundary = writer.add_section(TRACK_ID, 1, 64000, "buildup 1")
+    writer.undo(boundary)
+    sections = writer.fetch_annotations(TRACK_ID)["sections"]
+    assert len(sections) == 1
+    assert sections[0]["end_ms"] is None  # reopened: runs to track end again
+
+
+def test_nudge_cue_moves_at_ms(writer):
+    cue = writer.add_cue(TRACK_ID, 41000, "hit")
+    writer.nudge(cue, 41500)
+    assert writer.fetch_annotations(TRACK_ID)["cues"][0]["at_ms"] == 41500
+
+
+def test_nudge_section_moves_start_and_chained_previous_end(writer):
+    writer.add_section(TRACK_ID, 0, 0, "intro")
+    boundary = writer.add_section(TRACK_ID, 1, 64000, "buildup 1")
+    writer.nudge(boundary, 63500)
+    sections = writer.fetch_annotations(TRACK_ID)["sections"]
+    assert sections[1]["start_ms"] == 63500
+    assert sections[0]["end_ms"] == 63500  # the chained boundary moved with it
+
+
+def test_next_section_order_uses_max_not_count(writer):
+    writer.add_section(TRACK_ID, 0, 0, "intro")
+    middle = writer.add_section(TRACK_ID, 1, 64000, "buildup 1")
+    writer.add_section(TRACK_ID, 2, 130000, "drop 1")
+    writer.undo(middle)  # a hole in the orders must not cause a collision
+    assert writer.next_section_order(TRACK_ID) == 3
+
+
+def test_search_tracks_finds_by_case_insensitive_substring(writer):
+    matches = writer.search_tracks("cytestann str")
+    assert [m["id"] for m in matches] == [TRACK_ID]
+    assert matches[0]["duration_ms"] == 634000
+
+
+def test_duplicate_annotation_id_rejected_once_constraints_applied(writer, neo4j_driver):
+    from application.graph_database.initialize_database_environment import (
+        apply_uniqueness_constraints,
+    )
+    from application.annotations import model
+
+    apply_uniqueness_constraints(neo4j_driver)
+    params = model.build_note_params(TRACK_ID, "one")
+    writer._execute(model.INSERT_NOTE_QUERY, **params)
+    with pytest.raises(Exception):
+        writer._execute(model.INSERT_NOTE_QUERY, **params)  # same uuid: unique id violated

--- a/tests/test_annotations_cypher.py
+++ b/tests/test_annotations_cypher.py
@@ -3,7 +3,11 @@ Neo4j — the neo4j_driver fixture skips the module when the database isn't
 reachable. Distinctive CYTESTANN uris/ids keep cleanup surgical."""
 import pytest
 
-from application.annotations.model import Neo4jAnnotationWriter, TrackNotInGraphError
+from application.annotations.model import (
+    Neo4jAnnotationWriter,
+    SectionBoundaryError,
+    TrackNotInGraphError,
+)
 
 TRACK_ID = "CYTESTANN1"
 MISSING_TRACK_ID = "CYTESTANN_NOT_CRAWLED"
@@ -81,6 +85,68 @@ def test_sections_chain_next_and_close_open_ends(writer, neo4j_driver):
         track_id=TRACK_ID,
     )
     assert [(record["a"], record["b"]) for record in records] == [(0, 1), (1, 2)]
+
+
+def _chain(neo4j_driver):
+    """(a.label, b.label) pairs of the NEXT chain, ordered by time."""
+    records, _, _ = neo4j_driver.execute_query(
+        "MATCH (t:Track {id: $track_id})-[:HAS_SECTION]->(a:Section)-[:NEXT]->(b:Section) "
+        "WITH a, b ORDER BY a.start_ms "
+        "RETURN a.label AS a, b.label AS b",
+        track_id=TRACK_ID,
+    )
+    return [(record["a"], record["b"]) for record in records]
+
+
+def test_out_of_order_insert_chains_by_time_not_insertion_order(writer, neo4j_driver):
+    """The verifier's reproduction: 'drop 1' entered first at 2:10, 'intro'
+    remembered afterwards at 0:00. The chain must come out in time order with
+    no negative-length section."""
+    writer.add_section(TRACK_ID, 0, 130000, "drop 1")
+    writer.add_section(TRACK_ID, 1, 0, "intro")
+    sections = writer.fetch_annotations(TRACK_ID)["sections"]
+    assert [(s["label"], s["start_ms"], s["end_ms"]) for s in sections] == [
+        ("intro", 0, 130000),
+        ("drop 1", 130000, None),
+    ]
+    assert _chain(neo4j_driver) == [("intro", "drop 1")]
+    # invariant: end_ms >= start_ms everywhere
+    assert all(s["end_ms"] is None or s["end_ms"] >= s["start_ms"] for s in sections)
+
+
+def test_insert_between_existing_sections_relinks_the_chain(writer, neo4j_driver):
+    writer.add_section(TRACK_ID, 0, 0, "intro")
+    writer.add_section(TRACK_ID, 1, 130000, "drop 1")
+    writer.add_section(TRACK_ID, 2, 64000, "buildup 1")  # remembered late
+    sections = writer.fetch_annotations(TRACK_ID)["sections"]
+    assert [(s["label"], s["start_ms"], s["end_ms"]) for s in sections] == [
+        ("intro", 0, 64000),
+        ("buildup 1", 64000, 130000),
+        ("drop 1", 130000, None),
+    ]
+    # the old intro->drop edge was re-pointed through the new section
+    assert _chain(neo4j_driver) == [("intro", "buildup 1"), ("buildup 1", "drop 1")]
+
+
+def test_duplicate_section_start_is_rejected_loudly(writer):
+    writer.add_section(TRACK_ID, 0, 64000, "drop 1")
+    with pytest.raises(SectionBoundaryError):
+        writer.add_section(TRACK_ID, 1, 64000, "drop 1 again")
+    sections = writer.fetch_annotations(TRACK_ID)["sections"]
+    assert [s["label"] for s in sections] == ["drop 1"]  # nothing half-written
+
+
+def test_undo_middle_section_bridges_the_chain(writer, neo4j_driver):
+    writer.add_section(TRACK_ID, 0, 0, "intro")
+    writer.add_section(TRACK_ID, 1, 130000, "drop 1")
+    middle = writer.add_section(TRACK_ID, 2, 64000, "buildup 1")
+    writer.undo(middle)
+    sections = writer.fetch_annotations(TRACK_ID)["sections"]
+    assert [(s["label"], s["start_ms"], s["end_ms"]) for s in sections] == [
+        ("intro", 0, 130000),  # chain-derived end re-derived, not left dangling
+        ("drop 1", 130000, None),
+    ]
+    assert _chain(neo4j_driver) == [("intro", "drop 1")]
 
 
 def test_explicit_end_ms_is_not_overwritten_by_next_boundary(writer):

--- a/tests/test_annotations_mock_player.py
+++ b/tests/test_annotations_mock_player.py
@@ -1,0 +1,92 @@
+"""Tests for the mock's GET /v1/me/player route (plan 04 T5), hit over HTTP via
+the `spotify_mock` compose service. The mock_base fixture resets the control
+plane (including player state) before and after each test."""
+import time
+
+import requests
+
+
+def _configure(mock_base, **player_keys):
+    response = requests.post(f"{mock_base}/_control/config", json=player_keys)
+    response.raise_for_status()
+    return response.json()
+
+
+def test_default_player_state_is_track_zero_playing(mock_base):
+    response = requests.get(f"{mock_base}/v1/me/player")
+    assert response.status_code == 200
+    state = response.json()
+    assert state["is_playing"] is True
+    assert state["progress_ms"] == 0  # advance defaults off: deterministic
+    assert state["item"]["id"] == "trk000000"
+    assert state["item"]["href"].startswith(mock_base)  # self-referential
+    assert state["currently_playing_type"] == "track"
+
+
+def test_configure_exact_track_and_position(mock_base):
+    body = _configure(
+        mock_base, player_track_id="trk000003", player_progress_ms=41000
+    )
+    assert body["player_track_id"] == "trk000003"  # control echoes player state
+    state = requests.get(f"{mock_base}/v1/me/player").json()
+    assert state["item"]["id"] == "trk000003"
+    assert state["progress_ms"] == 41000  # frozen without player_advance
+    time.sleep(1.1)
+    assert requests.get(f"{mock_base}/v1/me/player").json()["progress_ms"] == 41000
+
+
+def test_progress_advances_with_wallclock_when_enabled(mock_base):
+    _configure(mock_base, player_progress_ms=1000, player_advance=True)
+    first = requests.get(f"{mock_base}/v1/me/player").json()["progress_ms"]
+    time.sleep(1.1)
+    second = requests.get(f"{mock_base}/v1/me/player").json()["progress_ms"]
+    assert second > first >= 1000
+    assert second - first >= 1000  # ~wall-clock ms elapsed between the polls
+
+
+def test_paused_player_does_not_advance(mock_base):
+    _configure(
+        mock_base, player_progress_ms=5000, player_advance=True, player_is_playing=False
+    )
+    state = requests.get(f"{mock_base}/v1/me/player").json()
+    assert state["is_playing"] is False
+    assert state["progress_ms"] == 5000
+
+
+def test_advance_flows_across_track_boundary_like_an_album(mock_base):
+    # Catalog tracks are 200000ms; park 100ms before the end of track 0 and
+    # let wall-clock advance carry playback into track 1.
+    _configure(mock_base, player_track_id="trk000000", player_progress_ms=199900, player_advance=True)
+    time.sleep(1.2)
+    state = requests.get(f"{mock_base}/v1/me/player").json()
+    assert state["item"]["id"] == "trk000001"
+    assert 0 <= state["progress_ms"] < 10000
+
+
+def test_no_active_device_is_204(mock_base):
+    _configure(mock_base, player_track_id=None)
+    assert requests.get(f"{mock_base}/v1/me/player").status_code == 204
+
+
+def test_control_reset_restores_default_player(mock_base):
+    _configure(mock_base, player_track_id="trk000007", player_progress_ms=12345)
+    requests.post(f"{mock_base}/_control/reset")
+    state = requests.get(f"{mock_base}/v1/me/player").json()
+    assert state["item"]["id"] == "trk000000" and state["progress_ms"] == 0
+
+
+def test_player_payload_shape_matches_what_listen_consumes(mock_base):
+    # PlaybackTracker reads is_playing, progress_ms, and item{id,name,
+    # duration_ms,artists[].name} — pin them so the mock stays load-bearing.
+    state = requests.get(f"{mock_base}/v1/me/player").json()
+    assert {"is_playing", "progress_ms", "item"} <= set(state)
+    item = state["item"]
+    assert {"id", "name", "duration_ms", "artists"} <= set(item)
+    assert all("name" in artist for artist in item["artists"])
+
+
+def test_failure_injection_applies_to_player_route_too(mock_base):
+    requests.post(f"{mock_base}/_control/config", json={"fail_next_n": 1, "fail_status": 429, "retry_after": 3})
+    first = requests.get(f"{mock_base}/v1/me/player")
+    assert first.status_code == 429 and first.headers.get("Retry-After") == "3"
+    assert requests.get(f"{mock_base}/v1/me/player").status_code == 200  # resumed

--- a/tests/test_annotations_model.py
+++ b/tests/test_annotations_model.py
@@ -123,7 +123,7 @@ def test_parse_position(text, expected):
     assert parse_position(text) == expected
 
 
-@pytest.mark.parametrize("bad", ["", None, "abc", "1:2:3:4", "-5", "12ms34"])
+@pytest.mark.parametrize("bad", ["", None, "abc", "1:2:3:4", "-5", "12ms34", "-500ms", "- 41000ms"])
 def test_parse_position_rejects_garbage(bad):
     with pytest.raises(ValueError):
         parse_position(bad)

--- a/tests/test_annotations_model.py
+++ b/tests/test_annotations_model.py
@@ -95,6 +95,7 @@ def test_insert_queries_only_touch_built_params(query, param_name, builder_keys)
     (model.DELETE_SECTION_QUERY, {"$section_id"}),
     (model.NUDGE_ANNOTATION_QUERY, {"$annotation_id", "$at_ms"}),
     (model.NEXT_SECTION_ORDER_QUERY, {"$track_id"}),
+    (model.TRACK_EXISTS_QUERY, {"$track_id"}),
 ])
 def test_parameterized_queries_use_exactly_the_params_the_writer_passes(query, expected_params):
     assert set(re.findall(r"\$\w+", query)) == expected_params

--- a/tests/test_annotations_model.py
+++ b/tests/test_annotations_model.py
@@ -51,6 +51,13 @@ def test_section_kind_outside_vocabulary_is_custom():
     assert model.build_section_params("trk1", 0, 0, "weird bit")["section"]["kind"] == "custom"
 
 
+def test_section_explicit_end_before_start_rejected():
+    # chain invariant: end_ms >= start_ms, enforced at the builder
+    with pytest.raises(ValueError):
+        model.build_section_params("trk1", 0, 10000, "verse", end_ms=9000)
+    assert model.build_section_params("trk1", 0, 10000, "verse", end_ms=10000)  # zero-length ok
+
+
 def test_section_explicit_kind_validated():
     section = model.build_section_params("trk1", 1, 5000, "the good part", kind="drop")["section"]
     assert section["kind"] == "drop"

--- a/tests/test_annotations_model.py
+++ b/tests/test_annotations_model.py
@@ -1,0 +1,145 @@
+"""Offline tests for the annotation model layer (plan 04 T1/T2): param-builder
+shapes, the contract between builders and the Cypher files, and the timecode
+helpers. No services required."""
+import re
+from datetime import datetime
+from uuid import UUID
+
+import pytest
+
+from application.annotations import model
+from application.annotations.timecode import format_ms, parse_position
+
+
+def _fields_accessed(query, param_name):
+    """All `param.field` accesses in a Cypher query, e.g. note.text."""
+    return set(re.findall(rf"\b{param_name}\.(\w+)", query))
+
+
+def test_note_params_shape():
+    params = model.build_note_params("trk1", "that switch-up at 2:10")
+    note = params["note"]
+    assert set(note) == {"track_id", "id", "text", "at_ms", "created_at"}
+    UUID(note["id"])  # app-side uuid4, parseable
+    assert note["at_ms"] is None  # cold entry: no position
+    datetime.fromisoformat(note["created_at"])  # tz-aware ISO 8601
+    assert datetime.fromisoformat(note["created_at"]).tzinfo is not None
+
+
+def test_note_params_with_live_position():
+    assert model.build_note_params("trk1", "hi", at_ms=130000.7)["note"]["at_ms"] == 130000
+
+
+def test_cue_params_shape():
+    cue = model.build_cue_params("trk1", 41000, "the drop")["cue"]
+    assert set(cue) == {"track_id", "id", "at_ms", "label", "created_at"}
+    assert cue["at_ms"] == 41000 and cue["label"] == "the drop"
+    UUID(cue["id"])
+
+
+def test_section_params_shape_and_derived_kind():
+    section = model.build_section_params("trk1", 0, 0, "Buildup 2")["section"]
+    assert set(section) == {
+        "track_id", "id", "order", "start_ms", "end_ms", "label", "kind", "created_at"
+    }
+    assert section["kind"] == "buildup"  # derived from the label's first word
+    assert section["end_ms"] is None  # open until the next boundary
+    UUID(section["id"])
+
+
+def test_section_kind_outside_vocabulary_is_custom():
+    assert model.build_section_params("trk1", 0, 0, "weird bit")["section"]["kind"] == "custom"
+
+
+def test_section_explicit_kind_validated():
+    section = model.build_section_params("trk1", 1, 5000, "the good part", kind="drop")["section"]
+    assert section["kind"] == "drop"
+    with pytest.raises(ValueError):
+        model.build_section_params("trk1", 1, 5000, "x", kind="guitar-solo")
+
+
+@pytest.mark.parametrize("label,expected", [
+    ("intro", "intro"),
+    ("Drop 1", "drop"),
+    ("  OUTRO  ", "outro"),
+    ("", "custom"),
+    (None, "custom"),
+    ("second verse", "custom"),  # kind keys off the FIRST word only
+])
+def test_normalize_kind(label, expected):
+    assert model.normalize_kind(label) == expected
+
+
+@pytest.mark.parametrize("query,param_name,builder_keys", [
+    (model.INSERT_NOTE_QUERY, "note", {"track_id", "id", "text", "at_ms", "created_at"}),
+    (model.INSERT_CUE_QUERY, "cue", {"track_id", "id", "at_ms", "label", "created_at"}),
+    (
+        model.INSERT_SECTION_QUERY,
+        "section",
+        {"track_id", "id", "order", "start_ms", "end_ms", "label", "kind", "created_at"},
+    ),
+])
+def test_insert_queries_only_touch_built_params(query, param_name, builder_keys):
+    # Every `param.field` the Cypher reads must exist in the builder's output,
+    # and the query must actually take the map as $param.
+    assert f"${param_name}" in query
+    assert _fields_accessed(query, param_name) <= builder_keys
+
+
+@pytest.mark.parametrize("query,expected_params", [
+    (model.FETCH_NOTES_QUERY, {"$track_id"}),
+    (model.FETCH_CUES_QUERY, {"$track_id"}),
+    (model.FETCH_SECTIONS_QUERY, {"$track_id"}),
+    (model.FETCH_TRACKS_BY_NAME_QUERY, {"$search_term"}),
+    (model.DELETE_ANNOTATION_QUERY, {"$annotation_id"}),
+    (model.DELETE_SECTION_QUERY, {"$section_id"}),
+    (model.NUDGE_ANNOTATION_QUERY, {"$annotation_id", "$at_ms"}),
+    (model.NEXT_SECTION_ORDER_QUERY, {"$track_id"}),
+])
+def test_parameterized_queries_use_exactly_the_params_the_writer_passes(query, expected_params):
+    assert set(re.findall(r"\$\w+", query)) == expected_params
+
+
+def test_uniqueness_constraints_appended_for_annotation_labels():
+    from application.config import APPLICATION_DIR
+    constraints_file = (
+        APPLICATION_DIR / "graph_database" / "queries" / "apply_uniqueness_constraints_to_nodes.cypher"
+    )
+    text = constraints_file.read_text()
+    for name in ("note_id_uniqueness", "cue_id_uniqueness", "section_id_uniqueness"):
+        assert name in text
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("2:10", 130000),
+    ("2:10.5", 130500),
+    ("1:02:03", 3723000),
+    ("90", 90000),
+    ("90.25", 90250),
+    ("41000ms", 41000),
+    ("0", 0),
+])
+def test_parse_position(text, expected):
+    assert parse_position(text) == expected
+
+
+@pytest.mark.parametrize("bad", ["", None, "abc", "1:2:3:4", "-5", "12ms34"])
+def test_parse_position_rejects_garbage(bad):
+    with pytest.raises(ValueError):
+        parse_position(bad)
+
+
+@pytest.mark.parametrize("ms,expected", [
+    (0, "0:00"),
+    (130000, "2:10"),
+    (130500, "2:10.500"),
+    (3723000, "62:03"),
+    (None, "-:--"),
+])
+def test_format_ms(ms, expected):
+    assert format_ms(ms) == expected
+
+
+def test_parse_format_round_trip():
+    for ms in (0, 500, 41000, 130500, 3_600_000):
+        assert parse_position(format_ms(ms)) == ms

--- a/tests/test_annotations_tracker.py
+++ b/tests/test_annotations_tracker.py
@@ -19,25 +19,41 @@ class FakeClock:
 
 
 class FakeWriter:
-    """Reuses the real param builders so records match production shapes."""
+    """Reuses the real param builders so records match production shapes.
 
-    def __init__(self, existing_orders=None):
+    graph_tracks mirrors the real writer's missing-track contract: None means
+    'everything is in the graph'; a set makes add_* raise TrackNotInGraphError
+    for ids outside it, exactly like Neo4jAnnotationWriter when the Track
+    MATCH finds nothing."""
+
+    def __init__(self, existing_orders=None, graph_tracks=None):
         self.records = []
         self.undone = []
         self.nudges = []
         self.existing_orders = existing_orders or {}
+        self.graph_tracks = graph_tracks
+
+    def _check_track(self, track_id):
+        if self.graph_tracks is not None and track_id not in self.graph_tracks:
+            raise model.TrackNotInGraphError(track_id)
+
+    def track_in_graph(self, track_id):
+        return self.graph_tracks is None or track_id in self.graph_tracks
 
     def add_note(self, track_id, text, at_ms=None):
+        self._check_track(track_id)
         record = {"type": "note", **model.build_note_params(track_id, text, at_ms=at_ms)["note"]}
         self.records.append(record)
         return record
 
     def add_cue(self, track_id, at_ms, label):
+        self._check_track(track_id)
         record = {"type": "cue", **model.build_cue_params(track_id, at_ms, label)["cue"]}
         self.records.append(record)
         return record
 
     def add_section(self, track_id, order, start_ms, label, kind=None, end_ms=None):
+        self._check_track(track_id)
         record = {
             "type": "section",
             **model.build_section_params(track_id, order, start_ms, label, kind=kind, end_ms=end_ms)["section"],
@@ -248,6 +264,61 @@ def test_session_summary_counts_by_type_and_track():
     assert summary["by_type"] == {"note": 1, "cue": 1, "section": 1}
     assert set(summary["by_track"]) == {"trk1", "trk2"}
     assert len(summary["by_track"]["trk1"]) == 2
+
+
+def test_poll_warns_on_track_change_when_track_not_in_graph():
+    writer = FakeWriter(graph_tracks=set())  # nothing crawled yet
+    tracker, _, _ = _tracker([_state("trk1"), _state("trk1")], writer=writer)
+    tracker.poll()
+    notices = tracker.drain_notices()
+    assert len(notices) == 1 and "NOT in the graph" in notices[0]
+    assert "[NOT IN GRAPH]" in tracker.status_line()
+    tracker.poll()  # same track: no repeat warning
+    assert tracker.drain_notices() == []
+
+
+def test_poll_stays_quiet_when_track_is_in_graph():
+    writer = FakeWriter(graph_tracks={"trk1"})
+    tracker, _, _ = _tracker([_state("trk1")], writer=writer)
+    tracker.poll()
+    assert tracker.drain_notices() == []
+    assert "[NOT IN GRAPH]" not in tracker.status_line()
+
+
+def test_capture_against_missing_track_is_an_explicit_failure():
+    writer = FakeWriter(graph_tracks=set())
+    tracker, _, _ = _tracker(
+        [_state("trk1", progress_ms=130000)],
+        writer=writer,
+        prompts=["lost thought", "the drop", "intro"],
+    )
+    tracker.poll()
+    tracker.drain_notices()
+    for key in ("n", "c", "s"):
+        feedback = tracker.handle_key(key)
+        assert "FAILED" in feedback and "NOT saved" in feedback
+    # nothing persisted, nothing undoable, nothing counted as a success
+    assert writer.records == []
+    assert tracker.undo_stack == []
+    summary = tracker.session_summary()
+    assert summary["total"] == 0
+    assert summary["failed"] == 3
+    assert [f["type"] for f in summary["failures"]] == ["note", "cue", "section"]
+    # the typed bodies survive in the summary so the session isn't lost
+    assert [f["body"] for f in summary["failures"]] == ["lost thought", "the drop", "intro"]
+    assert "3 FAILED" in tracker.status_line()
+
+
+def test_failed_section_capture_releases_its_order():
+    writer = FakeWriter(graph_tracks=set())
+    tracker, _, _ = _tracker(
+        [_state("trk1")], writer=writer, prompts=["intro", "intro again"]
+    )
+    tracker.poll()
+    assert "FAILED" in tracker.handle_key("s")  # order 0 claimed, write fails
+    writer.graph_tracks.add("trk1")  # the crawl catches up mid-session
+    tracker.handle_key("s")
+    assert writer.records[-1]["order"] == 0  # the failed claim was released
 
 
 def test_status_line_shows_track_position_and_capture_count():

--- a/tests/test_annotations_tracker.py
+++ b/tests/test_annotations_tracker.py
@@ -1,0 +1,260 @@
+"""Offline tests for PlaybackTracker (plan 04 T4): the poll-and-dispatch core
+of `listen`, driven with a fake fetch, fake clock, scripted prompts, and a fake
+writer — no TTY, no HTTP, no Neo4j."""
+import pytest
+
+from application.annotations import model
+from application.annotations.listen import NUDGE_STEP_MS, PlaybackTracker
+
+
+class FakeClock:
+    def __init__(self, start=1000.0):
+        self.now = start
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+class FakeWriter:
+    """Reuses the real param builders so records match production shapes."""
+
+    def __init__(self, existing_orders=None):
+        self.records = []
+        self.undone = []
+        self.nudges = []
+        self.existing_orders = existing_orders or {}
+
+    def add_note(self, track_id, text, at_ms=None):
+        record = {"type": "note", **model.build_note_params(track_id, text, at_ms=at_ms)["note"]}
+        self.records.append(record)
+        return record
+
+    def add_cue(self, track_id, at_ms, label):
+        record = {"type": "cue", **model.build_cue_params(track_id, at_ms, label)["cue"]}
+        self.records.append(record)
+        return record
+
+    def add_section(self, track_id, order, start_ms, label, kind=None, end_ms=None):
+        record = {
+            "type": "section",
+            **model.build_section_params(track_id, order, start_ms, label, kind=kind, end_ms=end_ms)["section"],
+        }
+        self.records.append(record)
+        return record
+
+    def undo(self, record):
+        self.undone.append(record)
+
+    def nudge(self, record, at_ms):
+        self.nudges.append((record["id"], at_ms))
+
+    def next_section_order(self, track_id):
+        return self.existing_orders.get(track_id, 0)
+
+
+def _item(track_id="trk1", name="Strobe", duration_ms=634000):
+    return {
+        "id": track_id,
+        "name": name,
+        "duration_ms": duration_ms,
+        "artists": [{"name": "deadmau5"}],
+    }
+
+
+def _state(track_id="trk1", progress_ms=41000, is_playing=True, **item_kwargs):
+    return {
+        "is_playing": is_playing,
+        "progress_ms": progress_ms,
+        "item": _item(track_id, **item_kwargs),
+    }
+
+
+def _tracker(states, writer=None, prompts=(), clock=None, prompt_advances=0.0):
+    """Build a tracker over scripted playback states and prompt answers.
+    prompt_advances simulates typing time: the clock moves while the prompt
+    blocks, which must NOT move already-captured positions."""
+    clock = clock or FakeClock()
+    writer = writer if writer is not None else FakeWriter()
+    state_iter = iter(states)
+    prompt_iter = iter(prompts)
+
+    def fetch():
+        return next(state_iter)
+
+    def prompt(_message):
+        clock.advance(prompt_advances)
+        return next(prompt_iter)
+
+    return PlaybackTracker(fetch, writer, prompt, clock=clock), writer, clock
+
+
+def test_poll_tracks_current_item():
+    tracker, _, _ = _tracker([_state(progress_ms=41000)])
+    state = tracker.poll()
+    assert state["item"]["id"] == "trk1"
+    assert tracker.track["name"] == "Strobe"
+    assert tracker.position_ms() == 41000
+
+
+def test_position_advances_with_wallclock_while_playing():
+    tracker, _, clock = _tracker([_state(progress_ms=41000, is_playing=True)])
+    tracker.poll()
+    clock.advance(2.5)
+    assert tracker.position_ms() == 43500
+
+
+def test_position_frozen_while_paused():
+    tracker, _, clock = _tracker([_state(progress_ms=41000, is_playing=False)])
+    tracker.poll()
+    clock.advance(10)
+    assert tracker.position_ms() == 41000
+
+
+def test_position_clamped_to_duration():
+    tracker, _, clock = _tracker([_state(progress_ms=633000, duration_ms=634000)])
+    tracker.poll()
+    clock.advance(60)
+    assert tracker.position_ms() == 634000
+
+
+def test_no_active_playback():
+    tracker, writer, _ = _tracker([None], prompts=["should not be asked"])
+    assert tracker.poll() is None
+    assert tracker.position_ms() is None
+    assert "no active playback" in tracker.handle_key("c")
+    assert writer.records == []
+    assert "-- no active playback --" in tracker.status_line()
+
+
+def test_cue_captured_at_keypress_time_not_after_prompt():
+    # The label takes 5s to type; the cue must land at the keypress position.
+    tracker, writer, clock = _tracker(
+        [_state(progress_ms=41000)], prompts=["the drop"], prompt_advances=5.0
+    )
+    tracker.poll()
+    clock.advance(1.0)  # 42000 at keypress
+    feedback = tracker.handle_key("c")
+    assert writer.records[0]["at_ms"] == 42000
+    assert "the drop" in feedback
+
+
+def test_note_carries_position_and_empty_note_discarded():
+    tracker, writer, _ = _tracker([_state(progress_ms=10000)], prompts=["nice pads", "   "])
+    tracker.poll()
+    tracker.handle_key("n")
+    assert writer.records[0]["type"] == "note" and writer.records[0]["at_ms"] == 10000
+    assert tracker.handle_key("n") == "empty - discarded"
+    assert len(writer.records) == 1
+
+
+def test_sections_chain_orders_from_graph_seed():
+    writer = FakeWriter(existing_orders={"trk1": 3})  # 3 cold-entry sections exist
+    tracker, _, _ = _tracker(
+        [_state(progress_ms=0)], writer=writer, prompts=["buildup 1", "drop 1"]
+    )
+    tracker.poll()
+    tracker.handle_key("s")
+    tracker.handle_key("s")
+    sections = [r for r in writer.records if r["type"] == "section"]
+    assert [s["order"] for s in sections] == [3, 4]
+    assert [s["kind"] for s in sections] == ["buildup", "drop"]
+
+
+def test_section_orders_are_per_track():
+    tracker, writer, _ = _tracker(
+        [_state("trk1"), _state("trk2")], prompts=["intro", "intro"]
+    )
+    tracker.poll()
+    tracker.handle_key("s")
+    tracker.poll()  # album plays on: next track
+    tracker.handle_key("s")
+    sections = writer.records
+    assert sections[0]["track_id"] == "trk1" and sections[0]["order"] == 0
+    assert sections[1]["track_id"] == "trk2" and sections[1]["order"] == 0
+
+
+def test_undo_pops_and_releases_section_order():
+    tracker, writer, _ = _tracker(
+        [_state()], prompts=["intro", "buildup 1", "buildup for real"]
+    )
+    tracker.poll()
+    tracker.handle_key("s")  # order 0
+    tracker.handle_key("s")  # order 1
+    feedback = tracker.handle_key("u")
+    assert "undid section" in feedback
+    assert writer.undone[0]["order"] == 1
+    tracker.handle_key("s")  # must reuse order 1, not skip to 2
+    assert writer.records[-1]["order"] == 1
+    assert len(tracker.session) == 2  # the undone record left the summary
+
+
+def test_undo_on_empty_stack():
+    tracker, writer, _ = _tracker([_state()])
+    tracker.poll()
+    assert tracker.handle_key("u") == "nothing to undo"
+    assert writer.undone == []
+
+
+def test_nudge_moves_last_capture_both_ways_and_floors_at_zero():
+    tracker, writer, _ = _tracker([_state(progress_ms=200)], prompts=["hit"])
+    tracker.poll()
+    tracker.handle_key("c")  # cue at 200ms
+    assert "nudged" in tracker.handle_key("+")
+    assert writer.records[0]["at_ms"] == 200 + NUDGE_STEP_MS
+    tracker.handle_key("-")
+    tracker.handle_key("-")  # 200 - 500 floors at 0
+    assert writer.records[0]["at_ms"] == 0
+    assert writer.nudges[-1] == (writer.records[0]["id"], 0)
+
+
+def test_nudge_section_moves_start_ms():
+    tracker, writer, _ = _tracker([_state(progress_ms=60000)], prompts=["drop 2"])
+    tracker.poll()
+    tracker.handle_key("s")
+    tracker.handle_key("-")
+    assert writer.records[0]["start_ms"] == 60000 - NUDGE_STEP_MS
+
+
+def test_nudge_with_nothing_captured():
+    tracker, _, _ = _tracker([_state()])
+    tracker.poll()
+    assert tracker.handle_key("+") == "nothing to nudge"
+
+
+def test_quit_and_unmapped_keys():
+    tracker, _, _ = _tracker([_state()])
+    tracker.poll()
+    assert tracker.handle_key("x") == ""
+    assert not tracker.quit_requested
+    tracker.handle_key("q")
+    assert tracker.quit_requested
+
+
+def test_session_summary_counts_by_type_and_track():
+    tracker, _, _ = _tracker(
+        [_state("trk1"), _state("trk2")],
+        prompts=["note one", "hit", "intro"],
+    )
+    tracker.poll()
+    tracker.handle_key("n")
+    tracker.handle_key("c")
+    tracker.poll()
+    tracker.handle_key("s")
+    summary = tracker.session_summary()
+    assert summary["total"] == 3
+    assert summary["by_type"] == {"note": 1, "cue": 1, "section": 1}
+    assert set(summary["by_track"]) == {"trk1", "trk2"}
+    assert len(summary["by_track"]["trk1"]) == 2
+
+
+def test_status_line_shows_track_position_and_capture_count():
+    tracker, _, _ = _tracker([_state(progress_ms=130000)], prompts=["hit"])
+    tracker.poll()
+    tracker.handle_key("c")
+    line = tracker.status_line()
+    assert "deadmau5 - Strobe" in line
+    assert "2:10" in line
+    assert "(1 captured)" in line

--- a/tests/test_annotations_tracker.py
+++ b/tests/test_annotations_tracker.py
@@ -1,10 +1,13 @@
 """Offline tests for PlaybackTracker (plan 04 T4): the poll-and-dispatch core
 of `listen`, driven with a fake fetch, fake clock, scripted prompts, and a fake
 writer — no TTY, no HTTP, no Neo4j."""
+import os
+import select
+
 import pytest
 
 from application.annotations import model
-from application.annotations.listen import NUDGE_STEP_MS, PlaybackTracker
+from application.annotations.listen import NUDGE_STEP_MS, PlaybackTracker, _read_key
 
 
 class FakeClock:
@@ -264,6 +267,34 @@ def test_quit_and_unmapped_keys():
     assert not tracker.quit_requested
     tracker.handle_key("q")
     assert tracker.quit_requested
+
+
+def test_read_key_burst_leaves_pending_keys_visible_to_select():
+    """A burst (auto-repeat on the nudge keys, a paste) arrives as multiple
+    bytes at once. Each read must take exactly ONE byte off the KERNEL buffer
+    so select() keeps reporting the rest — the buffered sys.stdin.read(1)
+    slurped the whole burst into a Python-level buffer select() can't see,
+    stranding all but the first key until a future keypress."""
+    read_fd, write_fd = os.pipe()
+    try:
+        os.write(write_fd, b"+++++q")
+        keys = []
+        while select.select([read_fd], [], [], 0)[0]:
+            keys.append(_read_key(read_fd))
+        # every key surfaced, one per select()-gated read, none stranded
+        assert keys == ["+", "+", "+", "+", "+", "q"]
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)
+
+
+def test_read_key_returns_none_on_eof():
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)  # writer gone: reads see EOF
+    try:
+        assert _read_key(read_fd) is None
+    finally:
+        os.close(read_fd)
 
 
 def test_session_summary_counts_by_type_and_track():

--- a/tests/test_annotations_tracker.py
+++ b/tests/test_annotations_tracker.py
@@ -32,6 +32,9 @@ class FakeWriter:
         self.nudges = []
         self.existing_orders = existing_orders or {}
         self.graph_tracks = graph_tracks
+        # Mirrors the real writer's nudge contract: False = the graph
+        # rejected the move (chain invariant) and nothing changed.
+        self.nudge_applied = True
 
     def _check_track(self, track_id):
         if self.graph_tracks is not None and track_id not in self.graph_tracks:
@@ -65,7 +68,10 @@ class FakeWriter:
         self.undone.append(record)
 
     def nudge(self, record, at_ms):
+        if not self.nudge_applied:
+            return False
         self.nudges.append((record["id"], at_ms))
+        return True
 
     def next_section_order(self, track_id):
         return self.existing_orders.get(track_id, 0)
@@ -232,6 +238,17 @@ def test_nudge_section_moves_start_ms():
     tracker.handle_key("s")
     tracker.handle_key("-")
     assert writer.records[0]["start_ms"] == 60000 - NUDGE_STEP_MS
+
+
+def test_rejected_nudge_keeps_local_record_in_sync_with_graph():
+    tracker, writer, _ = _tracker([_state(progress_ms=10000)], prompts=["hit"])
+    tracker.poll()
+    tracker.handle_key("c")  # cue at 10000
+    writer.nudge_applied = False  # graph refuses: would cross a boundary
+    feedback = tracker.handle_key("-")
+    assert "blocked" in feedback
+    assert writer.records[0]["at_ms"] == 10000  # local copy NOT moved
+    assert writer.nudges == []
 
 
 def test_nudge_with_nothing_captured():

--- a/tests/test_annotations_tracker.py
+++ b/tests/test_annotations_tracker.py
@@ -5,9 +5,16 @@ import os
 import select
 
 import pytest
+import requests
 
 from application.annotations import model
-from application.annotations.listen import NUDGE_STEP_MS, PlaybackTracker, _read_key
+from application.annotations.listen import (
+    NUDGE_STEP_MS,
+    POLL_BACKOFF_CAP_SECONDS,
+    RETRY_AFTER_CAP_SECONDS,
+    PlaybackTracker,
+    _read_key,
+)
 
 
 class FakeClock:
@@ -267,6 +274,71 @@ def test_quit_and_unmapped_keys():
     assert not tracker.quit_requested
     tracker.handle_key("q")
     assert tracker.quit_requested
+
+
+def _http_error(status, headers=None):
+    """A requests HTTPError carrying a response, like raise_for_status raises."""
+    response = requests.models.Response()
+    response.status_code = status
+    response.headers.update(headers or {})
+    return requests.exceptions.HTTPError(f"HTTP {status}", response=response)
+
+
+def _flaky_tracker(outcomes):
+    """A tracker whose fetch yields payloads or raises scripted exceptions."""
+    iterator = iter(outcomes)
+
+    def fetch():
+        outcome = next(iterator)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    writer = FakeWriter()
+    return PlaybackTracker(fetch, writer, lambda _m: "", clock=FakeClock()), writer
+
+
+def test_poll_survives_429_and_honors_capped_retry_after():
+    tracker, _ = _flaky_tracker([
+        _state(progress_ms=41000),
+        _http_error(429, {"Retry-After": "7"}),
+        _http_error(429, {"Retry-After": "86400"}),  # absurd server value
+    ])
+    tracker.poll()
+    assert tracker.poll() is None  # survived: no exception out of poll()
+    assert tracker.poll_backoff_seconds == 7.0  # Retry-After honored
+    assert tracker.track["id"] == "trk1"  # last-known state retained
+    assert "poll failing" in tracker.status_line()
+    tracker.poll()
+    assert tracker.poll_backoff_seconds == RETRY_AFTER_CAP_SECONDS  # ... but capped
+
+
+def test_poll_survives_5xx_and_timeouts_with_bounded_backoff():
+    outcomes = [_http_error(500)] * 3 + [requests.exceptions.ReadTimeout("read timed out")] * 7
+    tracker, _ = _flaky_tracker(outcomes)
+    backoffs = []
+    for _ in range(10):
+        assert tracker.poll() is None  # session keeps going every time
+        backoffs.append(tracker.poll_backoff_seconds)
+    assert backoffs[:3] == [1.0, 2.0, 4.0]  # exponential from the poll interval
+    assert max(backoffs) == POLL_BACKOFF_CAP_SECONDS  # bounded
+    assert "poll failing" in tracker.status_line()
+
+
+def test_poll_success_resets_backoff_and_clears_the_error():
+    tracker, _ = _flaky_tracker([
+        _http_error(502),
+        _http_error(502),
+        _state(progress_ms=41000),
+    ])
+    tracker.poll()
+    tracker.poll()
+    assert tracker.poll_backoff_seconds > 0
+    state = tracker.poll()
+    assert state["item"]["id"] == "trk1"
+    assert tracker.poll_backoff_seconds == 0.0
+    assert tracker.poll_error is None
+    assert "poll failing" not in tracker.status_line()
 
 
 def test_read_key_burst_leaves_pending_keys_visible_to_select():


### PR DESCRIPTION
Implements [docs/plans/04](../blob/main/docs/plans/04-annotations-and-dj-sets.md) phases A+B: the Note/Cue/Section graph model and two CLIs — `python3 -m application.annotations.annotate` (cold entry) and `...listen` (poll `/v1/me/player`, single-key hotkeys capture notes/cues/section boundaries at playback position, stdlib-only TTY).

- Section chains: `(:Track)-[:HAS_SECTION]->(:Section)-[:NEXT]->…` with **position-aware insertion** (time-ordered even when capturing out of order)
- Mock `/v1/me/player` route with scripted, wall-clock-advancing playback
- Adversarially reviewed: **7 confirmed findings fixed with fail-before regression tests** (silent discard when a track isn't in the graph → loud per-capture failure + session-summary record; chain corruption on out-of-order inserts; nudge inversion; buffered-stdin key desync → `os.read` on the raw fd; poll-loop dying on HTTP errors → bounded backoff; explicit end_ms erased by undo → provenance flag; `-500ms` accepted)

**Stack: based on `feat/entity-mastering` — merge that first (GitHub will retarget).**
Live use of `listen` needs the bundled re-auth (scope ships in the Plan 08 PR). Phases C/D (sets, HUD) are follow-ups per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)