### PR TITLE
feat(config): make CRAWL_LIKED_SONGS env-overridable

### DIFF
--- a/application/config.py
+++ b/application/config.py
@@ -18,7 +18,10 @@ def _env_bool(name, default):
 ###
 # Which searches to kick off
 ###
-CRAWL_LIKED_SONGS = True
+# Env-overridable so a run can crawl ONLY discographies (CRAWL_LIKED_SONGS=false
+# CRAWL_ARTIST_DISCOGRAPHIES=true) without redundantly re-paginating an already
+# crawled Liked Songs library. Defaults preserve the original behavior.
+CRAWL_LIKED_SONGS = _env_bool('CRAWL_LIKED_SONGS', True)
 CRAWL_FOLLOWED_PLAYLISTS = False
 CRAWL_FOLLOWED_ARTISTS = False
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -223,6 +223,9 @@ services:
       CRAWLED_URL_DEDUP: ${CRAWLED_URL_DEDUP:-true}
       CRAWL_ARTIST_DISCOGRAPHIES: ${CRAWL_ARTIST_DISCOGRAPHIES:-false}
       ARTIST_AFFINITY_MIN: ${ARTIST_AFFINITY_MIN:-3}
+      # Set CRAWL_LIKED_SONGS=false to run a discography-only crawl (skip
+      # re-paginating an already-crawled Liked Songs library).
+      CRAWL_LIKED_SONGS: ${CRAWL_LIKED_SONGS:-true}
       # Plan 06 multiplayer: which user(s) to seed for. Default: the primary
       # user (legacy no-user mode when nobody authorized via /login yet).
       #   CRAWL_USER=<spotify_user_id> docker compose up     one user


### PR DESCRIPTION
Small follow-up surfaced while running the first live discography crawl (plan 01).

`CRAWL_LIKED_SONGS` was a hard-coded `True`, so `CRAWL_ARTIST_DISCOGRAPHIES=true docker compose up` *also* re-paginated an already-crawled Liked Songs library (~628 redundant calls + noisy, hard-to-monitor logs). Now it's an `_env_bool` with a seeder passthrough, so a **discography-only** run is:

```
CRAWL_LIKED_SONGS=false CRAWL_ARTIST_DISCOGRAPHIES=true docker compose up
```

Default `true` preserves the original one-command behavior. Verified the flag reaches the container (`CRAWL_LIKED_SONGS=[false]`) and used live for the ≥10 discography validation crawl (seeder logged the discography seed with no Liked Songs fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)