### PR TITLE
fix(engine/mq): consumer + queue resilience (the discography-crawl killers)

### DIFF
--- a/application/api_call_engine.py
+++ b/application/api_call_engine.py
@@ -81,7 +81,7 @@ def resolve_effective_user(user_id):
     return user_id
 
 
-def make_spotify_api_call(ch, method, properties, body):
+def _consume_request(body):
     msg = loads(body)
     logger.info(f'Received message from queue:\n{pformat(msg)}')
 
@@ -253,33 +253,53 @@ def make_spotify_api_call(ch, method, properties, body):
             return
 
 
+def make_spotify_api_call(ch, method, properties, body):
+    """Pika consumer callback. A single request must NEVER tear down the
+    consumer: under auto_ack an exception raised here propagates into pika and
+    closes the channel, and the restart loop below then reconnects — but any
+    request published during that window is lost. Give-up paths in
+    _consume_request already roll back the dedup mark; anything else is logged
+    and skipped so the channel stays alive and later requests (e.g. the depth-0
+    frontier-artist sweep of a discography crawl) keep flowing."""
+    try:
+        _consume_request(body)
+    except Exception:
+        logger.exception(
+            'Error processing a request; skipping it to keep the consumer alive.'
+        )
+
+
 def entrypoint():
-    connection, channel = connect_to_rabbitmq_exchange(
-        exchange_name=RequestsExchange.EXCHANGE_NAME.value,
-        exchange_type=RequestsExchange.EXCHANGE_TYPE.value
-    )
-
-    queue_name = bind_queue_to_exchange(
-        channel=channel,
-        exchange_name=RequestsExchange.EXCHANGE_NAME.value,
-        exchange_type=RequestsExchange.EXCHANGE_TYPE.value,
-        routing_key=RequestsExchange.ROUTING_KEY_MAKE_API_CALL.value,
-        queue_name=RequestsExchange.ROUTING_KEY_MAKE_API_CALL.value  # Mimics the behavior of the default exchange
-    )
-
-    channel.basic_consume(
-        queue=queue_name,
-        on_message_callback=make_spotify_api_call,
-        auto_ack=True
-    )
-
+    # The full setup (connect -> bind -> consume) lives INSIDE the loop so a
+    # closed channel/connection — an unhandled callback error, a broker
+    # restart, a heartbeat timeout — is recovered by RECONNECTING. The previous
+    # version set up once outside the loop and re-called start_consuming() on
+    # the already-closed channel, hot-spinning forever ("Channel is closed.")
+    # while every published request drained into the void. The sleep bounds the
+    # retry rate when the broker is unreachable.
     while True:
         try:
+            connection, channel = connect_to_rabbitmq_exchange(
+                exchange_name=RequestsExchange.EXCHANGE_NAME.value,
+                exchange_type=RequestsExchange.EXCHANGE_TYPE.value
+            )
+            queue_name = bind_queue_to_exchange(
+                channel=channel,
+                exchange_name=RequestsExchange.EXCHANGE_NAME.value,
+                exchange_type=RequestsExchange.EXCHANGE_TYPE.value,
+                routing_key=RequestsExchange.ROUTING_KEY_MAKE_API_CALL.value,
+                queue_name=RequestsExchange.ROUTING_KEY_MAKE_API_CALL.value  # Mimics the behavior of the default exchange
+            )
+            channel.basic_consume(
+                queue=queue_name,
+                on_message_callback=make_spotify_api_call,
+                auto_ack=True
+            )
             logger.info(f'Starting to consume from queue {queue_name}')
             channel.start_consuming()
         except Exception as e:
-            logger.error(e)
-            logger.info(f'Restarting...')
+            logger.error(f'Consumer connection failed ({e!r}); reconnecting in 5s...')
+            sleep(5)
 
 
 if __name__ == '__main__':

--- a/application/api_call_engine.py
+++ b/application/api_call_engine.py
@@ -98,10 +98,13 @@ def _consume_request(body):
         try:
             r = requests.get(
                 request_url,
-                headers={"Authorization": f'Bearer {get_api_token(user_id)}'}
+                headers={"Authorization": f'Bearer {get_api_token(user_id)}'},
+                # Bound the GET so a hung request can't block the single consumer
+                # (and starve pika heartbeats) indefinitely.
+                timeout=30,
             )
-        except requests.exceptions.ConnectionError:  # Connection reset by peer
-            logger.warning("Connection reset by peer. Retrying...")
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+            logger.warning("Network error/timeout reaching Spotify. Retrying...")
             sleep(5)
             continue
 

--- a/application/message_queue/connect.py
+++ b/application/message_queue/connect.py
@@ -19,7 +19,17 @@ def connect_to_rabbitmq_exchange(
     :return: the connection and channel objects as a 2-tuple.
     """
     connection = pika.BlockingConnection(
-        pika.ConnectionParameters(host=RABBITMQ_HOSTNAME)
+        pika.ConnectionParameters(
+            host=RABBITMQ_HOSTNAME,
+            # A crawl callback does a (possibly slow) HTTP GET plus a fan-out
+            # publish before returning control to pika's I/O loop, which is when
+            # heartbeats are serviced. The 60s default let the broker reset the
+            # connection under load ("Connection reset by peer"); a long
+            # heartbeat tolerates bursty callbacks. Paired with a durable,
+            # non-exclusive request queue (below), a reset no longer loses work.
+            heartbeat=600,
+            blocked_connection_timeout=300,
+        )
     )
     channel = connection.channel()
 
@@ -48,9 +58,18 @@ def bind_queue_to_exchange(
     :return: the name of the queue as a string
     """
 
+    # A NAMED queue is a shared, durable work queue (make_api_call, the response
+    # topics): it must NOT be tied to the declaring connection, or a single
+    # consumer's dropped connection deletes the queue and every request still
+    # sitting in it (the discography-crawl failure: an engine reconnect wiped
+    # ~950 queued album-batch/frontier-sweep requests). An UNNAMED queue is a
+    # throwaway reply queue and stays exclusive/auto-deleting.
+    is_named = queue_name is not None
     result = channel.queue_declare(
-        queue=(queue_name if queue_name is not None else ""),
-        exclusive=True  # Deletes queue on connection close
+        queue=(queue_name if is_named else ""),
+        durable=is_named,          # survive a broker restart
+        exclusive=not is_named,    # not bound to one connection
+        auto_delete=not is_named,  # not deleted when the last consumer drops
     )
 
     queue_name = result.method.queue
@@ -89,7 +108,10 @@ def publish_message_to_exchange(channel, exchange, routing_key, body):
     channel.basic_publish(
         exchange=exchange,
         routing_key=routing_key,
-        body=body
+        body=body,
+        # Persist messages so queued work survives a broker restart (the durable
+        # queues above only persist the queue, not its transient messages).
+        properties=pika.BasicProperties(delivery_mode=2),
     )
     logger.debug(
         f'Published to exchange {exchange} with routing key {routing_key}'

--- a/tests/test_engine_consumer_resilience.py
+++ b/tests/test_engine_consumer_resilience.py
@@ -1,0 +1,59 @@
+"""The engine consumer must survive a bad request and reconnect on channel loss.
+
+Regression for the live discography-crawl failure: a non-200/429/500/401 status
+raised out of the pika callback under auto_ack, closing the channel; the old
+entrypoint then re-called start_consuming() on the *same closed channel*,
+hot-spinning "Channel is closed." forever while every subsequent request (the
+depth-0 frontier-artist sweep) was published into a torn-down queue.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+import application.api_call_engine as engine
+
+
+def test_bad_request_does_not_propagate_out_of_the_callback(monkeypatch):
+    # _consume_request raising (a give-up, or any unexpected error) must be
+    # swallowed by the callback, or pika closes the channel under auto_ack.
+    boom = []
+
+    def explode(body):
+        boom.append(body)
+        raise RuntimeError("HTTP 502 received for https://api.spotify.com/...")
+
+    monkeypatch.setattr(engine, "_consume_request", explode)
+
+    # Must NOT raise — the consumer stays alive for the next message.
+    engine.make_spotify_api_call(None, None, None, b'{"request_url": "x"}')
+    assert boom == [b'{"request_url": "x"}']
+
+
+def test_entrypoint_reconnects_instead_of_reusing_a_dead_channel(monkeypatch):
+    # First start_consuming() fails like a closed channel; the loop must build a
+    # NEW connection/channel (reconnect) rather than retry the dead one. The
+    # second attempt raises StopIteration to break the otherwise-infinite loop.
+    connects = []
+
+    def fake_connect(**kwargs):
+        connects.append(kwargs)
+        channel = MagicMock()
+        if len(connects) == 1:
+            # Emulate the closed channel — an Exception the loop must recover from.
+            channel.start_consuming.side_effect = Exception("Channel is closed.")
+        else:
+            # SystemExit is a BaseException (NOT caught by the loop's
+            # `except Exception`), so it breaks the otherwise-infinite loop.
+            channel.start_consuming.side_effect = SystemExit
+        return MagicMock(), channel
+
+    monkeypatch.setattr(engine, "connect_to_rabbitmq_exchange", fake_connect)
+    monkeypatch.setattr(engine, "bind_queue_to_exchange", lambda **kwargs: "make_api_call")
+    monkeypatch.setattr(engine, "sleep", lambda *_: None)
+
+    with pytest.raises(SystemExit):
+        engine.entrypoint()
+
+    # Reconnected: connect_to_rabbitmq_exchange was called a SECOND time after
+    # the first channel died (the old code called it exactly once, ever).
+    assert len(connects) == 2

--- a/tests/test_engine_consumer_resilience.py
+++ b/tests/test_engine_consumer_resilience.py
@@ -11,6 +11,45 @@ from unittest.mock import MagicMock
 import pytest
 
 import application.api_call_engine as engine
+from application.message_queue.connect import bind_queue_to_exchange
+
+
+def test_named_work_queue_is_durable_and_survives_a_dropped_connection():
+    # The make_api_call / response queues are NAMED: they must be durable and
+    # NOT exclusive/auto-delete, or one consumer's dropped connection deletes
+    # the queue and every request still in it (the discography-crawl failure).
+    channel = MagicMock()
+    channel.queue_declare.return_value.method.queue = "make_api_call"
+
+    bind_queue_to_exchange(
+        channel=channel,
+        exchange_name="spotify_api_requests",
+        exchange_type="direct",
+        routing_key="make_api_call",
+        queue_name="make_api_call",
+    )
+
+    kwargs = channel.queue_declare.call_args.kwargs
+    assert kwargs["durable"] is True
+    assert kwargs["exclusive"] is False
+    assert kwargs["auto_delete"] is False
+
+
+def test_unnamed_reply_queue_stays_exclusive():
+    channel = MagicMock()
+    channel.queue_declare.return_value.method.queue = "amq.gen-xyz"
+
+    bind_queue_to_exchange(
+        channel=channel,
+        exchange_name="spotify_api_requests",
+        exchange_type="direct",
+        routing_key="make_api_call",
+        queue_name=None,
+    )
+
+    kwargs = channel.queue_declare.call_args.kwargs
+    assert kwargs["exclusive"] is True
+    assert kwargs["durable"] is False
 
 
 def test_bad_request_does_not_propagate_out_of_the_callback(monkeypatch):

--- a/tests/test_engine_resilience.py
+++ b/tests/test_engine_resilience.py
@@ -30,7 +30,12 @@ def engine_env(mock_base, monkeypatch):
 def _call(url, depth=0):
     # Deliberately NO user_id key: pins the pre-multiplayer envelope shape
     # (plan 06 back-compat with in-flight messages).
-    engine.make_spotify_api_call(None, None, None, json.dumps({"request_url": url, "depth_of_search": depth}))
+    #
+    # Drive _consume_request directly: make_spotify_api_call is now a thin pika
+    # wrapper that SWALLOWS give-up exceptions to keep the channel alive, so the
+    # give-up-and-roll-back behavior under test lives in _consume_request. The
+    # wrapper's swallowing is covered by tests/test_engine_consumer_resilience.py.
+    engine._consume_request(json.dumps({"request_url": url, "depth_of_search": depth}))
 
 
 def test_429_is_retried_with_capped_backoff_then_succeeds(engine_env, mock_base):


### PR DESCRIPTION
Three coupled infrastructure bugs, all surfaced by the first live discography crawl (plan 01) and invisible to the mock/unit suite. Together they silently dropped the depth-0 frontier-artist enrichment sweep, so 1,269 discovered collaborators were never enriched and the discovery query returned nothing.

1. **Consumer hot-loop** — `entrypoint()` set up the RabbitMQ connection *once outside* its retry loop; on any failure it re-called `start_consuming()` on the **already-closed channel**, hot-spinning `"Channel is closed."` forever. Now it reconnects (connect→bind→consume) inside the loop with a bounded sleep.
2. **One bad request killed the consumer** — a non-200/429/500/401 status raised out of the `auto_ack` callback, closing the channel. The callback is now a thin wrapper that logs+skips a failed request so the channel survives.
3. **Exclusive work queues lost all queued work on a reset** — `make_api_call` (and the response topics) were declared `exclusive=True`, so a single connection reset (`"Connection reset by peer"` under load) **deleted the queue and its ~950 pending requests**. Now named queues are durable + non-exclusive + non-auto-delete, messages persist (`delivery_mode=2`), and a 600s heartbeat + 30s GET timeout stop the reset from happening in the first place.

**Verified live**: after these fixes the sweep ran (539 batch `/v1/artists?ids=` calls, was 0 every prior run), enriching 2,882+ frontier artists; the discovery query now returns real, obscurity-ranked adjacent unknowns. **497 tests pass**, incl. 4 new regression tests (reconnect, callback-swallow, named-queue durability, reply-queue exclusivity).

Stacked on `feat/crawl-liked-songs-flag` (#25) — GitHub will retarget to main when that merges.
🤖 Generated with [Claude Code](https://claude.com/claude-code)