### PR TITLE
Stop the test suite from clobbering real Spotify tokens

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -261,7 +261,12 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
-      - "./secrets:/src/secrets"
+      # Read-only: the suite must NEVER write the real tokens. Even if a test
+      # forgets to isolate token_store to tmp_path, :ro turns a silent clobber of
+      # secrets/spotify_*.secret + secrets/users/ (which breaks the live app's
+      # auth) into a loud failure. The non-token secrets tests legitimately read
+      # (neo4j creds, client id/secret) stay readable.
+      - "./secrets:/src/secrets:ro"
       - "./tests:/src/tests"
       # mock_spotify normally runs as the spotify_mock service, but tests that
       # drive the catalog/mock app in-process (plans 03 + 08) import it

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,46 @@ from types import SimpleNamespace
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def guard_real_secrets_untouched():
+    """Fail any test that writes token files under the REAL secrets/ dir.
+
+    Regression guard for the secrets-clobber bug: token-store / OAuth / refresh
+    tests MUST monkeypatch the token paths (token_store.USERS_DIR,
+    PRIMARY_USER_FILE, LEGACY_*_TOKEN_FILE and refresh_token.SPOTIFY_*_FILE) to
+    tmp_path. A test that reaches the real SECRETS_DIR silently overwrites the
+    live app's Spotify tokens — the primary<->legacy two-way mirror in
+    refresh_token.py made an incompletely-isolated refresh test do exactly that,
+    turning secrets/spotify_api_token.secret (and the primary's namespaced copy)
+    into the literal "mock-access-token" on every `docker compose run tests`.
+
+    Snapshot the real token files before each test and assert they are
+    byte-for-byte unchanged after (covers writes, creations, and deletions).
+    """
+    from application import config
+
+    def snapshot():
+        secrets_dir = config.SECRETS_DIR
+        watched = [secrets_dir / "spotify_api_token.secret",
+                   secrets_dir / "spotify_refresh_token.secret"]
+        users = secrets_dir / "users"
+        if users.is_dir():
+            watched += [p for p in users.rglob("*") if p.is_file()]
+        return {str(p): (p.read_bytes() if p.is_file() else None) for p in watched}
+
+    before = snapshot()
+    yield
+    after = snapshot()
+    if before != after:
+        modified = sorted(k for k in set(before) | set(after)
+                          if before.get(k) != after.get(k))
+        raise AssertionError(
+            f"test wrote to the REAL secrets dir ({config.SECRETS_DIR}): "
+            f"{modified}. Token-store/OAuth/refresh tests must monkeypatch the "
+            "token paths to tmp_path (see tests/test_token_store.py::store)."
+        )
+
+
 def _artist(i, popularity=None, followers=None):
     """popularity/followers: None -> deterministic defaults; "" -> omit the
     field entirely (a simplified artist object, e.g. a track credit, carries

--- a/tests/test_refresh_token.py
+++ b/tests/test_refresh_token.py
@@ -9,6 +9,7 @@ does), so both regressions are pinned here end-to-end.
 import requests
 
 import application.spotify_authentication.refresh_token as rt
+from application.spotify_authentication import token_store
 
 
 def _wire_secrets(monkeypatch, tmp_path, mock_base):
@@ -21,6 +22,16 @@ def _wire_secrets(monkeypatch, tmp_path, mock_base):
     monkeypatch.setattr(rt, "SPOTIFY_API_TOKEN_FILE", tmp_path / "spotify_api_token.secret")
     monkeypatch.setattr(rt, "SPOTIFY_REFRESH_TOKEN_FILE", tmp_path / "spotify_refresh_token.secret")
     monkeypatch.setattr(rt, "SPOTIFY_ACCOUNTS_BASE_URL", mock_base)
+    # A legacy (user_id=None) refresh ALSO mirrors into the primary's namespaced
+    # dir via token_store (refresh_token.py's two-way mirror). Isolate those
+    # paths too, or refresh_spotify_auth() reaches the REAL secrets/users/ +
+    # legacy files and overwrites the live app's tokens with the mock's. Point
+    # LEGACY_* at the same tmp files rt writes, so the mirror stays consistent.
+    monkeypatch.setattr(token_store, "USERS_DIR", tmp_path / "users")
+    monkeypatch.setattr(token_store, "PRIMARY_USER_FILE", tmp_path / "users" / ".primary_user")
+    monkeypatch.setattr(token_store, "LEGACY_API_TOKEN_FILE", tmp_path / "spotify_api_token.secret")
+    monkeypatch.setattr(token_store, "LEGACY_REFRESH_TOKEN_FILE",
+                        tmp_path / "spotify_refresh_token.secret")
 
 
 def test_refresh_authenticates_and_rewrites_access_token(monkeypatch, tmp_path, mock_base):


### PR DESCRIPTION
## Problem

`docker compose run --rm tests` silently overwrote the live app's real Spotify tokens: after a full suite run, `secrets/spotify_api_token.secret` and `secrets/users/<primary>/spotify_api_token.secret` both contained the literal `mock-access-token` / `mock-refresh-token`, breaking the running crawl's auth at the next refresh.

## Root cause

**Not** the multiplayer tests the symptom pointed at — those already isolate `token_store` to `tmp_path`. The offender was `tests/test_refresh_token.py`, whose `_wire_secrets` helper (written for the PR #16 refresh-auth fix) isolates `refresh_token`'s `SPOTIFY_*_FILE` globals but **not** `token_store`'s.

The plan-06 multiplayer work later gave `refresh_spotify_auth()` a **primary↔legacy two-way mirror**: a legacy (`user_id=None`) refresh reads the real `secrets/users/.primary_user` and calls `token_store.save_tokens(primary, …)`, writing both the per-user dir and the legacy files. With the tests service mounting `./secrets`, the incompletely-isolated refresh test reached the real tokens and wrote the mock's values into them. The test passed while corrupting live auth.

## Fix

- **`tests/test_refresh_token.py`** — `_wire_secrets` also monkeypatches the four `token_store` paths (`USERS_DIR`, `PRIMARY_USER_FILE`, `LEGACY_API_TOKEN_FILE`, `LEGACY_REFRESH_TOKEN_FILE`) to `tmp_path`.
- **`tests/conftest.py`** — autouse `guard_real_secrets_untouched` fixture: snapshots the real token files before/after **every** test and fails any test that mutates them (always-on regression guard).
- **`compose.yaml`** — the tests service mounts `./secrets` read-only (`:ro`). The non-token secrets tests legitimately read (neo4j creds, client id/secret) stay readable, so no coverage is lost; a future un-isolated write becomes a loud failure instead of silent corruption.

## Verification

Run in an isolated compose project (separate Redis/RabbitMQ; worktree `secrets/` seeded with throwaway fakes) so the live crawl was never touched:

- **Reproduced** — the offending test clobbered the seeded tokens to `mock-access-token`; the new guard caught it.
- **After the fix** — the test passes with seeds untouched.
- **Full suite** — 428 passed, 68 skipped; seeds byte-for-byte untouched; guard green on every test.

## Not in scope

The suite also has 3 **pre-existing** failures in `tests/test_engine_resilience.py` (`DID NOT RAISE HTTPError`) that reproduce with this branch's changes stashed and are unrelated to secrets (the engine's retry-exhaustion re-raise path — the mock's failure injection was verified to work). Being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
