### PR TITLE
fix(workers): response-worker consumer resilience

### DIFF
--- a/application/response_handlers/main.py
+++ b/application/response_handlers/main.py
@@ -1,5 +1,6 @@
 import argparse
 from json import loads
+from time import sleep
 from urllib.parse import urlparse, parse_qs
 
 from application.config import SECRETS_DIR, SPOTIFY_API_BASE_URL
@@ -106,6 +107,20 @@ class SpotifyResponseController:
 
     @staticmethod
     def dispatch_to_response_parser(ch, method, properties, body):
+        """Consumer callback wrapper: a single bad message (a handler error or a
+        transient Neo4j write blip) must NOT propagate into pika and close the
+        channel — under auto_ack that stalls the whole worker (the write_to_neo4j
+        backlog freeze). Log and skip; entrypoint()'s reconnect loop handles
+        connection-level failures."""
+        try:
+            SpotifyResponseController._dispatch(ch, method, properties, body)
+        except Exception:
+            logger.exception(
+                'Error handling a response message; skipping it to keep the consumer alive.'
+            )
+
+    @staticmethod
+    def _dispatch(ch, method, properties, body):
         global RESPONSE_HANDLER_ACTION
 
         msg = loads(body)
@@ -135,32 +150,35 @@ class SpotifyResponseController:
 
 
 def entrypoint(response_handler_action):
-    connection, channel = connect_to_rabbitmq_exchange(
-        exchange_name=ResponsesExchange.EXCHANGE_NAME.value,
-        exchange_type=ResponsesExchange.EXCHANGE_TYPE.value
-    )
-
-    queue_name = bind_queue_to_exchange(
-        channel=channel,
-        exchange_name=ResponsesExchange.EXCHANGE_NAME.value,
-        exchange_type=ResponsesExchange.EXCHANGE_TYPE.value,
-        routing_key=response_handler_action,
-        queue_name=response_handler_action  # Mimics the behavior of the default exchange
-    )
-
-    channel.basic_consume(
-        queue=queue_name,
-        on_message_callback=SpotifyResponseController.dispatch_to_response_parser,
-        auto_ack=True
-    )
-
+    # Full setup INSIDE the loop so a closed channel/connection (a broker
+    # restart, a heartbeat timeout, a connection reset under load) is recovered
+    # by RECONNECTING. The old version set up once outside the loop and
+    # re-called start_consuming() on the already-closed channel, hot-spinning
+    # "Channel is closed." forever while the durable queue's messages piled up
+    # unconsumed (the write_to_neo4j backlog freeze). Bounded sleep on retry.
     while True:
         try:
+            connection, channel = connect_to_rabbitmq_exchange(
+                exchange_name=ResponsesExchange.EXCHANGE_NAME.value,
+                exchange_type=ResponsesExchange.EXCHANGE_TYPE.value
+            )
+            queue_name = bind_queue_to_exchange(
+                channel=channel,
+                exchange_name=ResponsesExchange.EXCHANGE_NAME.value,
+                exchange_type=ResponsesExchange.EXCHANGE_TYPE.value,
+                routing_key=response_handler_action,
+                queue_name=response_handler_action  # Mimics the behavior of the default exchange
+            )
+            channel.basic_consume(
+                queue=queue_name,
+                on_message_callback=SpotifyResponseController.dispatch_to_response_parser,
+                auto_ack=True
+            )
             logger.info(f'Starting to consume from queue {queue_name}')
             channel.start_consuming()
         except Exception as e:
-            logger.error(e)
-            logger.info(f'Restarting...')
+            logger.error(f'Consumer connection failed ({e!r}); reconnecting in 5s...')
+            sleep(5)
 
 
 if __name__ == '__main__':

--- a/tests/test_engine_consumer_resilience.py
+++ b/tests/test_engine_consumer_resilience.py
@@ -52,6 +52,43 @@ def test_unnamed_reply_queue_stays_exclusive():
     assert kwargs["durable"] is False
 
 
+def test_response_worker_entrypoint_reconnects_on_channel_loss(monkeypatch):
+    # Same bug as the engine, but in the response workers (write_to_neo4j et al):
+    # a closed channel must trigger a RECONNECT, not a hot-spin on the dead one
+    # (which froze the durable write_to_neo4j backlog live).
+    import application.response_handlers.main as rmain
+
+    connects = []
+
+    def fake_connect(**kwargs):
+        connects.append(kwargs)
+        channel = MagicMock()
+        channel.start_consuming.side_effect = (
+            Exception("Channel is closed.") if len(connects) == 1 else SystemExit
+        )
+        return MagicMock(), channel
+
+    monkeypatch.setattr(rmain, "connect_to_rabbitmq_exchange", fake_connect)
+    monkeypatch.setattr(rmain, "bind_queue_to_exchange", lambda **kwargs: "write_to_neo4j")
+    monkeypatch.setattr(rmain, "sleep", lambda *_: None)
+
+    with pytest.raises(SystemExit):
+        rmain.entrypoint("write_to_neo4j")
+
+    assert len(connects) == 2  # reconnected after the first channel died
+
+
+def test_response_worker_callback_swallows_a_bad_message(monkeypatch):
+    import application.response_handlers.main as rmain
+
+    def boom(ch, method, properties, body):
+        raise RuntimeError("neo4j write blip")
+
+    monkeypatch.setattr(rmain.SpotifyResponseController, "_dispatch", staticmethod(boom))
+    # Must NOT raise — the worker stays alive for the next message.
+    rmain.SpotifyResponseController.dispatch_to_response_parser(None, None, None, b"{}")
+
+
 def test_bad_request_does_not_propagate_out_of_the_callback(monkeypatch):
     # _consume_request raising (a give-up, or any unexpected error) must be
     # swallowed by the callback, or pika closes the channel under auto_ack.


### PR DESCRIPTION
Follow-up to #26. That PR fixed the engine's consumer loop but the same hot-loop-on-closed-channel bug lived in all three response workers (`response_handlers/main.py`). It bit live during the resumed ≥3 crawl: the `write_to_neo4j` worker's connection reset under load and it spun `Channel is closed.` forever with 0 consumers while its durable queue backed up (472 msgs preserved but unconsumed). Same two-part fix as the engine — callback wrapper (log+skip, channel survives) + reconnecting entrypoint — with mirrored regression tests. 6 resilience tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)