### PR TITLE
Documentation blitz: top-down docs, C4 diagrams (Lucid + Mermaid), per-folder READMEs, skills, cleanup

### DIFF
--- a/.claude/skills/annotate-listening/SKILL.md
+++ b/.claude/skills/annotate-listening/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: annotate-listening
+description: Capture notes, cue points, and section maps on tracks — cold entry by track name or live hotkey capture while music plays. Use when asked to annotate a track, mark cues/sections, run a listening session, or query existing annotations.
+---
+
+# Annotate tracks
+
+Full guide (hotkeys, formats, graph shape):
+**[application/annotations/README.md](../../../application/annotations/README.md)**.
+
+```bash
+# Cold entry: search the graph by name, annotate from prompts
+docker compose run --rm responses_write_to_neo4j \
+    python3 -m application.annotations.annotate "track name"
+
+# Live capture: start playback anywhere, then tap hotkeys in this terminal
+# (n note · c cue · s section · u undo · +/- nudge 500ms · q quit+summary)
+docker compose run --rm responses_write_to_neo4j \
+    python3 -m application.annotations.listen
+```
+
+Constraints to check first: the track must already be in the graph (inserts
+MATCH, never create — crawl first); live capture needs the
+`user-read-playback-state` scope ([docs/auth.md](../../../docs/auth.md)) and
+polls ~1 s, so positions are ±1–2 s (nudge with `+`/`-`). Against the mock,
+add `-e SPOTIFY_API_BASE_URL=http://spotify_mock` and drive the fake player
+via `POST /_control/config` ([mock_spotify/README.md](../../../mock_spotify/README.md)).
+
+Read annotations back:
+`MATCH (t:Track)-[:HAS_NOTE|HAS_CUE|HAS_SECTION]->(x) RETURN t.name, labels(x), x`.

--- a/.claude/skills/connect-mcp/SKILL.md
+++ b/.claude/skills/connect-mcp/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: connect-mcp
+description: Connect an AI client (Claude Code, Claude Desktop) to the spotify-graph MCP server, verify it works, and troubleshoot. Use when asked to set up the MCP server, hook Claude to the graph, or debug MCP connection issues in this project.
+---
+
+# Connect the graph MCP server
+
+Setup, tools, limitations, ChatGPT-gap: **[mcp_server/README.md](../../../mcp_server/README.md)**.
+
+The short version:
+
+- **Claude Code**: nothing to do — the repo's `.mcp.json` registers it; a
+  fresh session in this repo picks it up.
+- **Claude Desktop**: add the `spotify-graph` block from the README to
+  `~/Library/Application Support/Claude/claude_desktop_config.json` with the
+  absolute path to `scripts/mcp_server.sh`.
+- **ChatGPT Desktop**: not supported (remote-HTTP-only client vs this stdio
+  server) — the README explains the gap and the tunnel-shaped workaround to
+  avoid.
+
+Prerequisites: image built (`docker compose build`), Neo4j Desktop running,
+`secrets/neo4j_credentials.yaml` present.
+
+Verify: ask the client to call `graph_schema` — node counts should come back.
+Troubleshooting order: (1) Docker running? (2) image built / worktree
+`IMAGE_TAG` built? (3) Neo4j reachable — first tool call fails without it even
+though the server lists tools fine; (4) code changes need a rebuild or the
+bind-mount dev loop from the README. Server logs go to **stderr** (stdout is
+the protocol channel).

--- a/.claude/skills/explore-graph/SKILL.md
+++ b/.claude/skills/explore-graph/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: explore-graph
+description: Explore the crawled taste graph in Neo4j — orientation queries, the ten common questions, two-user overlap analysis, MCP-assisted exploration. Use when asked to query the graph, analyze taste, find discoveries, compare users, or answer any "what does my music data say" question.
+---
+
+# Explore the taste graph
+
+The tutorial is **[docs/exploring-the-graph.md](../../../docs/exploring-the-graph.md)**:
+orientation queries, ten copy-paste questions (top artists, genre profile,
+taste-over-time, deep cuts, discovery frontier, mastering roll-ups, album
+loyalty), and the two-user overlap tour. What the nodes/edges mean:
+[docs/data-model.md](../../../docs/data-model.md).
+
+Ways to run queries, best first:
+
+1. **MCP tools** (if connected — see the `connect-mcp` skill): `graph_schema`
+   first, then `find_artist` / `collaborators_of` / `discover_adjacent`, and
+   `run_cypher_readonly` for everything else. Read-only, row-capped.
+2. **Curated query packs** in `application/graph_database/queries/`
+   (`overlap/` takes `$a`/`$b` user ids; `discovery/`, `mastering/` too) —
+   tested, parameterized, ready to paste into the Neo4j browser.
+3. **Ad-hoc Cypher** against `bolt://127.0.0.1:7687` (credentials in
+   `secrets/neo4j_credentials.yaml`).
+
+Prerequisites worth checking before deep analysis:
+
+- Artist `popularity` null everywhere? Run the enrichment:
+  `docker compose run --rm responses_write_to_neo4j python3 -m application.discovery.backfill_artists`
+- Duplicate-looking tracks? Run mastering first (`master-library` skill).
+- Comparing two users? Both must be crawled (`onboard-second-user` skill).

--- a/.claude/skills/master-library/SKILL.md
+++ b/.claude/skills/master-library/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: master-library
+description: Run entity mastering — dedupe re-releases/remasters/radio edits into canonical Song nodes, review the ambiguity report, apply manual overrides. Use when asked to master the library, dedupe songs, merge track versions, or fix a wrong song merge/split.
+---
+
+# Run entity mastering
+
+Full explanation: **[application/mastering/README.md](../../../application/mastering/README.md)**;
+the graph shapes it writes: [docs/data-model.md](../../../docs/data-model.md#story-2-five-releases-one-song-mastering).
+
+The loop:
+
+```bash
+# 0. only if tracks lack ISRCs (report will warn):
+docker compose run --rm responses_write_to_neo4j python3 -m application.mastering.backfill
+
+# 1. cluster (idempotent, safe to re-run after every crawl)
+docker compose run --rm responses_write_to_neo4j python3 -m application.mastering.run
+
+# 2. review — most ambiguous clusters listed first
+cat data/mastering_review.md
+```
+
+3. Wrong merge or split? Add the track ids to
+   `secrets/mastering_overrides.yaml` (format:
+   `application/mastering/overrides.example.yaml` — `merge:` groups and
+   `split:` groups; overrides always win) and re-run step 1.
+
+Knows-before-you-ask: remixes never merge with their parent (they get
+`REMIX_OF` edges); "Taylor's Version" re-recordings stay separate Songs on
+purpose; re-runs re-point edges and never delete anything.

--- a/.claude/skills/mock-crawl/SKILL.md
+++ b/.claude/skills/mock-crawl/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: mock-crawl
+description: Run the full pipeline offline against the bundled mock Spotify — no real account, deterministic catalog, on-demand failure injection. Use when asked to run offline, demo the pipeline, test failure handling live, or crawl without touching real Spotify.
+---
+
+# Run a mock-backed crawl (offline)
+
+Background: [docs/delivery.md](../../../docs/delivery.md#path-3-the-offline-mock-crawl)
+and [mock_spotify/README.md](../../../mock_spotify/README.md).
+
+```bash
+# mock tokens satisfy the auth gate (no OAuth needed)
+echo -n mock-access-token  > secrets/spotify_api_token.secret
+echo -n mock-refresh-token > secrets/spotify_refresh_token.secret
+
+RESET_CRAWL=true docker compose -f compose.yaml -f docker-compose.mock.yml up
+```
+
+The overlay points every service's Spotify URLs at `http://spotify_mock`; the
+crawl runs entirely offline against a deterministic ~60-track catalog
+(size knobs: `MOCK_N_TRACKS` etc.). Monitor exactly like a real crawl
+([docs/observability.md](../../../docs/observability.md)).
+
+Inject failures mid-run to watch the engine cope:
+
+```bash
+docker compose exec spotify_mock curl -s -X POST http://localhost/_control/config \
+    -d '{"fail_next_n": 5, "fail_status": 429, "retry_after": 2}'
+docker compose exec spotify_mock curl -s -X POST http://localhost/_control/reset
+```
+
+Cautions: don't overwrite real tokens — check whether
+`secrets/spotify_api_token.secret` holds a real token before step 1 (back it
+up or run from a worktree checkout); and the mock writes mock nodes into
+whatever Neo4j the stack points at, so prefer a scratch database (or
+`RESET_CRAWL=true` + purge `MATCH (t:Track) WHERE t.id STARTS WITH 'trk' DETACH DELETE t`
+afterwards).

--- a/.claude/skills/onboard-second-user/SKILL.md
+++ b/.claude/skills/onboard-second-user/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: onboard-second-user
+description: Add a friend's Spotify library to the shared taste graph — allowlist, OAuth login, migration 0001, per-user crawl, overlap queries. Use when asked to add a user, onboard a friend, set up multiplayer, crawl someone else's library, or compare two users' taste.
+---
+
+# Onboard a second user (multiplayer)
+
+Follow **[docs/multiplayer-runbook.md](../../../docs/multiplayer-runbook.md)** —
+it is the authoritative step-by-step. Background reading:
+[docs/auth.md](../../../docs/auth.md) (primary-user mirror, token layout) and
+[docs/data-model.md](../../../docs/data-model.md) (the ownership layer).
+
+The checklist, compressed:
+
+1. **One-time** (if the graph predates multiplayer): run migration 0001 with
+   the owner's Spotify user id, then have the owner re-auth via `/login`.
+2. **Allowlist the friend** in the Spotify developer dashboard (Settings →
+   User Management → their account email) — development-mode apps reject
+   everyone else at the consent screen.
+3. **Friend logs in** at `http://127.0.0.1:8000/login` → "Add a user" (tunnel
+   port 8000 if remote). Their tokens land in `secrets/users/<their_id>/`.
+4. **Crawl them**: `CRAWL_USER=<their_id> docker compose up requests_factory_start_crawls`
+   (or `CRAWL_ALL_USERS=true` — sequential on purpose; rate limits are per-app).
+5. **Explore the overlap**: the query pack tour is in
+   [docs/exploring-the-graph.md](../../../docs/exploring-the-graph.md#the-shared-music-space-when-a-friends-library-is-loaded).
+
+Mind the two hard rules: never delete `secrets/users/.primary_user` or the
+legacy `secrets/spotify_*.secret` files (they gate compose), and say out loud
+that the friend's data lands in the host's Neo4j. Deletion procedure ("right
+to be forgotten") is in the runbook §4.

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: run-tests
+description: Run the Spotify Power Browser test suite in Docker and interpret the results (skips vs failures, service dependencies, safety rails). Use when asked to run tests, verify a change, check the suite, or investigate a test failure in this project.
+---
+
+# Run the test suite
+
+Everything you need to know is in **[docs/testing.md](../../../docs/testing.md)**
+(the four layers, safety rails, gaps) and **[tests/README.md](../../../tests/README.md)**
+(per-file index). Short version:
+
+```bash
+docker compose run --rm tests                          # everything
+docker compose run --rm tests python3 -m pytest tests/test_dispatcher.py -v
+docker compose run --rm tests python3 -m pytest tests/ -k "mastering" -v
+```
+
+Compose brings up RabbitMQ, Redis, and the mock Spotify automatically.
+
+## Interpreting results
+
+- **Skips are normal**: Neo4j-dependent tests skip when Neo4j Desktop isn't
+  running; `mcp` wiring tests skip on a stale image. Failures are never normal.
+- **After changing code, rebuild first**: `docker compose build` (tests/ and
+  mock_spotify/ are volume-mounted, but application/ and mcp_server/ are baked
+  into the image).
+- **"test wrote to the REAL secrets dir"** — the test is missing a tmp_path
+  monkeypatch for token paths; see the `store` fixture in
+  `tests/test_token_store.py` and docs/testing.md.
+- In a Claude worktree the stack is auto-isolated (own image tag + project,
+  no host ports) — safe to run alongside a live crawl on the primary checkout.

--- a/.claude/skills/spin-up/SKILL.md
+++ b/.claude/skills/spin-up/SKILL.md
@@ -173,5 +173,5 @@ docker compose down -v               # also wipe the Redis dedup volume
 - **Tokens last ~1h.** Long crawls rely on the 401-refresh path; a fresh token is
   written on each `/callback`.
 - **`USE_BATCH_ENDPOINTS` is default-off.** Only enable after probing batch access
-  with `_probe_batch_endpoints.py` (Spotify postponed, not cancelled, removing
+  with `scripts/probes/probe_batch_endpoints.py` (Spotify postponed, not cancelled, removing
   the `?ids=` endpoints for existing apps).

--- a/.claude/skills/sync-playlists/SKILL.md
+++ b/.claude/skills/sync-playlists/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: sync-playlists
+description: Generate or update Spotify playlists from the graph (adjacent-discoveries, exploration-queue, blend) with dry-run/apply semantics and managed-playlist safety. Use when asked to create/update/sync a playlist, push discoveries to Spotify, or roll back a playlist change.
+---
+
+# Sync graph-generated playlists to Spotify
+
+Full explanation and safety model:
+**[application/playlists/README.md](../../../application/playlists/README.md)**.
+
+```bash
+# ALWAYS dry-run first (it's the default — prints the diff, writes nothing)
+docker compose run --rm responses_write_to_neo4j \
+    python3 -m application.playlists.sync adjacent-discoveries
+
+# apply for real
+docker compose run --rm responses_write_to_neo4j \
+    python3 -m application.playlists.sync adjacent-discoveries --apply
+```
+
+Generators: `adjacent-discoveries` (needs a discography crawl),
+`exploration-queue "<artist>"`, `blend <user_a> <user_b>` (needs two crawled
+users). Requires the `playlist-modify-private` scope
+([docs/auth.md](../../../docs/auth.md)).
+
+Guardrails to respect (and tell the human about):
+
+- Writes only to playlists recorded as `(:ManagedPlaylist)` — refuses
+  hand-made playlists by construction. Never work around this.
+- Show the human the dry-run diff before `--apply` unless they've already
+  said to apply.
+- Rollback: the node's `target_snapshots` keeps the last 3 track lists —
+  procedure in the README.

--- a/README.md
+++ b/README.md
@@ -1,100 +1,128 @@
 # Spotify Power Browser
 
-For tastemakers and audiophiles of all kinds. A data-engineering pipeline that
-crawls the Spotify Web API and builds a graph of your musical taste in Neo4j.
+For tastemakers and audiophiles of all kinds: a local data-engineering
+pipeline that copies your Spotify listening data into a **graph database**,
+then gives you (and your friends, and your AI assistant) ways to explore it
+that Spotify never will.
 
-It runs as a set of containerized workers wired together by RabbitMQ, with a
-Redis-backed crawl dedup cache — the whole thing comes up with a single
-`docker compose up`, including the one-time Spotify OAuth flow.
+One `docker compose up` brings up the whole thing — message queue, crawler
+workers, even the Spotify login flow — and about twenty minutes later your
+entire library is a graph you can query.
 
-## Architecture
+```mermaid
+flowchart LR
+    spotify["🎵 Spotify<br/>Web API"]
+    pipeline["🐳 Crawler pipeline<br/>(Docker Compose:<br/>RabbitMQ + Redis + Python workers)"]
+    graphdb[("🕸️ Neo4j<br/>your taste graph")]
+    you(["🧑‍🎤 You + friends<br/>Cypher, playlists"])
+    ai(["🤖 AI assistants<br/>via MCP"])
 
+    spotify -- "crawl (read)" --> pipeline --> graphdb
+    graphdb --> you
+    graphdb --> ai
+    you -- "generated playlists (write, guarded)" --> spotify
 ```
-requests_factory ──► Requests exchange ──► api_call_engine ──► Spotify Web API
-   (seeds a crawl)      (RabbitMQ)         (GET, retry/backoff)      │
-                                                                     ▼
-                                              Responses exchange (fan-out ×4, RabbitMQ)
-                                                                     │
-            ┌────────────────────┬───────────────────┬──────────────┴────────┐
-            ▼                    ▼                   ▼                        ▼
-      write_to_disk        write_to_neo4j       follow_links            write_to_sqlite
-      (JSON cache)         (graph insert)     (re-queues URLs)            (stub, off)
-                                                     │
-                                                     └──► back to Requests exchange
-                                                          (recursive crawl, depth-limited)
-```
 
-- **Graph model:** `Track`, `Album`, `Artist`, `Genre` nodes; `CONTAINS`,
-  `CREATED`, `SPOTIFY_CLASSIFIED_AS` relationships. Everything is `MERGE`d on
-  stable Spotify IDs, so re-crawling is idempotent.
-- **Dedup:** every outbound request flows through one choke point
-  (`requests_factory.request_url`) and is checked against a durable Redis set, so
-  redundant follow requests don't flood the API (and trip rate limits).
+## What can it actually do?
 
-## Prerequisites
+- **Crawl** your Liked Songs — and optionally the full discographies of the
+  artists you clearly love — into `Track`/`Album`/`Artist`/`Genre` nodes.
+  Idempotent (re-crawls update, never duplicate), rate-limit-respecting, and
+  restartable.
+- **Master** your library: roll "Levitating", "Levitating – Radio Edit" and
+  the deluxe re-release into one canonical *Song*, with a human review loop.
+- **Multiplayer**: a friend logs in, their library lands in the same graph,
+  and a query pack answers "what do we share, where do we diverge, what's
+  new to both of us?"
+- **Annotate** tracks while you listen — cue points, section maps, notes —
+  straight into the graph from hotkeys.
+- **Write back**: turn graph insights into real Spotify playlists, with
+  dry-run defaults and a hard rule that it never touches playlists it didn't
+  create.
+- **Talk to it**: a read-only MCP server lets Claude explore the graph
+  conversationally.
 
-- **Docker Desktop** (running).
-- **Neo4j Desktop** with a database running (`bolt://127.0.0.1:7687`). The crawler
-  connects to it from inside Docker via `host.docker.internal`. _(Alternatively,
-  run Neo4j fully in Docker — see the commented `neo4j` service in
-  `compose.yaml`.)_
-- **A registered Spotify app** (https://developer.spotify.com/dashboard) with:
-  - the **redirect URI `http://127.0.0.1:8000/callback`** registered (Spotify
-    rejects `localhost` as insecure — it must be the loopback IP).
-  - its client ID and secret available for `secrets/` (below).
+## Quickstart
 
-## Setup
+You need three things installed and one thing registered:
 
-Populate `secrets/` (all gitignored):
+1. **Docker Desktop**, running.
+2. **Neo4j Desktop** with a database started (`bolt://127.0.0.1:7687`) — the
+   graph lives here, on the host, [on purpose](docs/architecture.md#why-isnt-neo4j-a-container).
+3. **A Spotify app** ([dashboard](https://developer.spotify.com/dashboard))
+   with redirect URI `http://127.0.0.1:8000/callback` registered — the
+   loopback IP exactly; Spotify rejects `localhost`.
+
+Then populate `secrets/` (gitignored):
 
 | File | Contents |
 |------|----------|
-| `secrets/spotify_client_id.secret` | your Spotify app client ID |
-| `secrets/spotify_client_secret.secret` | your Spotify app client secret |
-| `secrets/neo4j_credentials.yaml` | `username: neo4j` / `password: <your Neo4j Desktop password>` |
+| `secrets/spotify_client_id.secret` | your Spotify app's client ID |
+| `secrets/spotify_client_secret.secret` | your Spotify app's client secret |
+| `secrets/neo4j_credentials.yaml` | `username: neo4j` / `password: <your password>` |
 
-The OAuth token files are written here automatically by the auth flow.
-
-## Run
+And run it:
 
 ```bash
 docker compose up
 ```
 
-What happens, in one command:
-1. RabbitMQ, Redis, and the response workers start.
-2. The **bundled Spotify auth service** serves a login page and the pipeline
-   **waits** (a token healthcheck gates it) until you authorize.
-3. Open **http://127.0.0.1:8000/login**, log into Spotify, click **Agree**. The
-   callback writes your tokens to `secrets/`.
-4. The healthcheck flips green, the gate releases, and the crawl of your Liked
-   Songs begins — writing JSON to `data/responses/` and the graph to Neo4j.
+The stack starts, then **waits for you**: open http://127.0.0.1:8000/login,
+log into Spotify, click Agree. Your token lands on disk, a healthcheck flips
+green, and the crawl begins — raw JSON to `data/responses/`, the graph to
+Neo4j. Watch it run at http://localhost:15672 (guest/guest) — the crawl is
+done when the queues are empty and the rates hit zero
+([how to read that screen](docs/observability.md)).
 
-## Configuration (`application/config.py`, all env-overridable)
+## Configuration
+
+All flags live in [application/config.py](application/config.py) and are
+overridable at the shell, e.g. `RESET_CRAWL=true docker compose up`:
 
 | Setting | Default | Purpose |
 |---------|---------|---------|
-| `CRAWL_LIKED_SONGS` | `True` | crawl your saved tracks |
-| `DEPTH_OF_SEARCH` | `1` | how far to follow neighbors |
-| `CRAWLED_URL_DEDUP` | `True` | skip already-requested URLs (Redis) |
-| `RESET_CRAWL` | `False` | clear the dedup set for a fresh crawl (set `true` to re-crawl from scratch) |
-| `USE_BATCH_ENDPOINTS` | `False` | use Spotify's `?ids=` batch endpoints (~22× fewer calls) — see note below |
-| `NEO4J_HOSTNAME` / `REDIS_HOSTNAME` / `RABBITMQ_HOSTNAME` | service names | point at host vs container services |
+| `CRAWL_LIKED_SONGS` | `true` | crawl your saved tracks |
+| `CRAWL_ARTIST_DISCOGRAPHIES` | `false` | also crawl full discographies of artists with ≥ `ARTIST_AFFINITY_MIN` (3) liked tracks |
+| `USE_BATCH_ENDPOINTS` | `false` | Spotify's multi-id endpoints, ~22× fewer calls (live-verified for this app; re-verify with `scripts/probes/probe_batch_endpoints.py` if in doubt) |
+| `CRAWLED_URL_DEDUP` | `true` | skip already-fetched URLs (Redis, persists across runs) |
+| `RESET_CRAWL` | `false` | forget fetched URLs and crawl fresh (per-user in multiplayer mode) |
+| `CRAWL_USER` / `CRAWL_ALL_USERS` | primary / `false` | whose library to crawl (multiplayer) |
+| `DEPTH_OF_SEARCH` | `1` | how many hops to follow from a response |
 
-> **Batch endpoints:** Spotify postponed (not cancelled) removing the multi-id
-> `?ids=` endpoints for existing apps. Verify with `_probe_batch_endpoints.py`
-> before enabling; the per-item path is the safe default.
+## Where do I go next?
 
-## Monitoring
+| I want to… | Read |
+|---|---|
+| understand how the pieces fit together | [docs/architecture.md](docs/architecture.md) |
+| understand what's *in* the graph | [docs/data-model.md](docs/data-model.md) |
+| actually explore my data (tutorial) | [docs/exploring-the-graph.md](docs/exploring-the-graph.md) |
+| hook up Claude to the graph | [mcp_server/README.md](mcp_server/README.md) |
+| add a friend's library | [docs/multiplayer-runbook.md](docs/multiplayer-runbook.md) |
+| understand the login/token machinery | [docs/auth.md](docs/auth.md) |
+| run tests / understand coverage | [docs/testing.md](docs/testing.md) |
+| know how builds & runs work (incl. offline mock runs) | [docs/delivery.md](docs/delivery.md) |
+| watch a crawl and interpret what I see | [docs/observability.md](docs/observability.md) |
+| compare the Lucid vs Mermaid diagrams | [docs/diagrams/README.md](docs/diagrams/README.md) |
+| see what's done and what's next | [ROADMAP.md](ROADMAP.md) · [docs/plans/](docs/plans/README.md) |
 
-- **RabbitMQ Management UI — http://localhost:15672** (`guest`/`guest`): the
-  Queues tab shows per-stage backlog and live message rates. The crawl is done
-  when rates flatline to 0 and queues are empty.
-- **Logs:** `docker compose logs -f api_call_engine` (the live GET stream),
-  `docker compose logs -f responses_write_to_neo4j` (node/edge counts).
-- **Throughput pulse:** `docker compose logs --since 10s api_call_engine | grep -c 'GET:'` (0 = idle).
-- **Graph:** the Neo4j Desktop browser, e.g. `MATCH (a:Artist)-[:CREATED]->(t:Track) RETURN a,t LIMIT 100`.
-- **Disk cache:** `find data/responses -name '*.json' | wc -l`.
+Every folder also has its own README (start at
+[application/README.md](application/README.md)).
+
+## The post-crawl toolkit
+
+```bash
+# enrich artists with popularity/followers (discovery ranking needs this)
+docker compose run --rm responses_write_to_neo4j python3 -m application.discovery.backfill_artists
+
+# dedupe releases into canonical Songs, then read data/mastering_review.md
+docker compose run --rm responses_write_to_neo4j python3 -m application.mastering.run
+
+# annotate while listening (hotkeys: n note, c cue, s section, q quit)
+docker compose run --rm responses_write_to_neo4j python3 -m application.annotations.listen
+
+# turn discoveries into a real playlist (dry-run by default; --apply to do it)
+docker compose run --rm responses_write_to_neo4j python3 -m application.playlists.sync adjacent-discoveries
+```
 
 ## Tests
 
@@ -102,39 +130,11 @@ What happens, in one command:
 docker compose run --rm tests
 ```
 
-A pytest suite (unit + integration) that brings up RabbitMQ + Redis and targets
-the host Neo4j Desktop; integration tests skip if a service is down.
-
-## Annotations (notes, cues, section maps)
-
-Timestamped listening annotations over crawled tracks (plan 04, phases A–B):
-`(:Track)-[:HAS_NOTE|HAS_CUE|HAS_SECTION]->(…)`, sections chained with `NEXT`.
-
-- **Cold entry** — search a track by name in the graph, annotate from prompts:
-  ```bash
-  docker compose run --rm responses_write_to_neo4j \
-      python3 -m application.annotations.annotate "track name"
-  ```
-- **Live capture** — put an album on (any device), keep a terminal open, tap
-  keys as it plays. Polls `/v1/me/player` ~1s; hotkeys: `n` note, `c` cue,
-  `s` section boundary, `u` undo, `+`/`-` nudge 500ms, `q` quit + summary:
-  ```bash
-  docker compose run --rm responses_write_to_neo4j \
-      python3 -m application.annotations.listen
-  ```
-
-> **Scope note:** live capture reads `GET /v1/me/player`, which requires the
-> `user-read-playback-state` OAuth scope — part of the bundled re-auth
-> (docs/plans/README.md, "Do these first"); until you re-authorize, it 403s
-> against live Spotify. It works today against the mock:
-> `docker compose run --rm -e SPOTIFY_API_BASE_URL=http://spotify_mock …`.
+Unit, integration, end-to-end, and failure-injection tests against a bundled
+mock Spotify; your real secrets are mounted read-only so the suite can't
+touch them. Details: [docs/testing.md](docs/testing.md).
 
 ## Stack
 
-Python 3.13 · Poetry 2.4 · RabbitMQ 4 · Redis 8 · Neo4j 6 (driver) · Falcon 4 ·
-pika · pandas 3.
-
-## More
-
-- **Roadmap & status:** [ROADMAP.md](ROADMAP.md)
-- **Design notes (mock Spotify service, AWS):** [docs/](docs/)
+Python 3.13 · Poetry 2.4 · Falcon 4 · pika/RabbitMQ 4 · Redis 8 ·
+Neo4j (driver 6) · pytest 8 · MCP SDK. Everything ships in one Docker image.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,154 +1,80 @@
 # Spotify Power Browser — Roadmap & Status
 
-_Last updated: 2026-07-06_
+_Last updated: 2026-07-08_
 
-> **2026-07-06 — first full-library crawl completed** (12,547 tracks / 9,832
-> albums / 7,587 artists / 634 genres, ~18 min, zero 429s, batching on), and a
-> full set of forward-looking feature plans landed in **[docs/plans/](docs/plans/README.md)**:
-> adjacent-artist discovery, listening completeness, entity mastering,
-> annotations & DJ sets, a graph MCP server, multiplayer, beyond-Spotify
-> (local files + SoundCloud), playlist write-back, and taste-over-time.
-> Those plans supersede the sketches in Stages 2–4 below where they overlap
-> (each plan says which). The **live-verified API surface** (what this app
-> retains post-deprecations) is tabled in the plans README.
+Where the project **is** and where it goes **next**. How things work is
+documented in [docs/](docs/README.md); feature designs live in
+[docs/plans/](docs/plans/README.md).
 
-A personal data-engineering project that crawls the Spotify Web API and builds a
-graph of your musical taste in Neo4j. This document is the single source of truth
-for **where the project is** and **where it needs to go next**.
+## Where the project is
 
----
+The first full-library crawl completed 2026-07-06: **12,547 tracks / 9,832
+albums / 7,587 artists / 634 genres in ~18 minutes**, zero rate-limit errors,
+batch endpoints on. Since then, six of the nine feature plans have shipped:
 
-## 1. Architecture at a glance
+| Shipped | What you get | PR |
+|---|---|---|
+| One-command run | `docker compose up` including the OAuth flow, healthcheck-gated | #2 |
+| Crawl correctness | Redis dedup, capped 429 backoff, token refresh with client auth, durable queues, consumer reconnect | #2 #14 #16 #26 #29 |
+| Mock Spotify + resilience tests | offline crawls, failure injection, the test suite | #11–#13 |
+| Plan 01 — adjacent-artist discovery | depth-2 discography crawl, frontier artists, popularity backfill | #22 |
+| Plan 03 — entity mastering | canonical Songs across re-releases, review-report loop | #20 |
+| Plan 04 (A+B) — annotations | cold-entry + live hotkey capture of notes/cues/sections | #21 |
+| Plan 05 — graph MCP server | AI exploration of the graph, read-only | #19 |
+| Plan 06 — multiplayer | `(:User)-[:LIKED]` ownership layer, migrations, overlap query pack | #24 |
+| Plan 08 — playlist write-back | managed playlists, diff-sync, dry-run default | #23 |
 
-A message-queue pipeline glued together by two RabbitMQ `direct` exchanges:
+## What's next
 
-```
-requests_factory ──► Requests exchange ──► api_call_engine ──► Spotify Web API
-                                                  │
-                                                  ▼
-                                          Responses exchange  (fan-out ×4)
-                                                  │
-              ┌───────────────────┬───────────────┼───────────────────┐
-              ▼                   ▼                ▼                   ▼
-        write_to_disk      write_to_neo4j     follow_links      write_to_sqlite
-        (JSON cache)       (graph insert)   (re-queues URLs)    (stubbed / OFF)
-                                                  │
-                                                  └──► back to Requests exchange
-                                                       (recursive crawl, depth-limited)
-```
+**Feature plans, in rough priority order** (designs in docs/plans/):
 
-- **`requests_factory.py`** — seeds a crawl by publishing Spotify URLs onto the Requests exchange.
-- **`api_call_engine.py`** — consumes requests, makes the HTTP GET (handles 429/500/401, auto-paginates via `next`), and fans each response out to the four response handlers.
-- **`response_handlers/`** — four worker roles selected by CLI arg: `write_to_disk`, `write_to_neo4j`, `follow_links`, `write_to_sqlite`.
-- **`follow_links`** is what makes it a *crawler*: it re-queues the track/album/artist URLs found in a response at `depth − 1`.
+- [ ] **Plan 02 — listening completeness.** Ingest Spotify's extended
+  streaming-history export into `(:User)-[:DID]->(:Play)` nodes; upgrade
+  `artist_completeness` out of degraded mode. Blocked on requesting the
+  export (days–weeks of lead time), not on code. Would also implement the two
+  remaining handler stubs (`my_followed_playlists`, `my_followed_artists`).
+- [ ] **Plan 09 — taste over time.** The `added_at` data is already in the
+  graph; needs the analytics/report layer (year-in-review, `time-capsule`
+  playlist generator).
+- [ ] **Plan 07 — beyond Spotify.** Local files + SoundCloud. XL effort,
+  spike first.
+- [ ] **Plan 04 phases C+D** — DJ set planning + playback HUD on top of
+  annotations.
 
-### Graph data model (Neo4j)
+**Platform work:**
 
-- **Nodes:** `Track`, `Album`, `Artist`, `Genre` (uniqueness constraints on `Track.id`, `Album.id`, `Artist.id`).
-- **Relationships:**
-  - `(Album)-[:CONTAINS]->(Track)`
-  - `(Artist)-[:CREATED]->(Track)` and `(Artist)-[:CREATED]->(Album)`
-  - `(Album|Artist)-[:SPOTIFY_CLASSIFIED_AS]->(Genre)`
-- Everything is `MERGE`d on stable Spotify IDs, so re-crawling is idempotent — and (see Stage 4) two users' libraries loaded into one DB would naturally share nodes.
+- [ ] **MCP `shared_taste` tool** — plan 06's schema shipped; wrap the overlap
+  query pack as a first-class tool (today it's reachable via the cookbook).
+- [ ] **CI** — a GitHub Actions workflow (build image, run the
+  non-Neo4j-dependent test subset). Nothing blocks this; it just hasn't been
+  wanted yet.
+- [ ] **AWS migration** — mock-service-first strategy per
+  [docs/mock-spotify-service.md](docs/mock-spotify-service.md): deploy the
+  mock to Fargate as the learning workload, then the real pipeline
+  (workers → Fargate, RabbitMQ → Amazon MQ/SQS, Redis → ElastiCache,
+  Neo4j → Aura, secrets → Secrets Manager).
+- [ ] **Graph-explorer UI** — the original "power browser" promise; today the
+  Neo4j browser + MCP server stand in.
+- [ ] **Observability upgrades** if unattended runs ever matter: turn on the
+  structured-log formatter, add basic metrics
+  (see [docs/observability.md](docs/observability.md#the-gaps-things-you-might-expect-and-wont-find)).
 
----
+**Known dead weight (cleanup candidates):**
 
-## 2. Current status
+- `write_to_sqlite` — a fourth response-handler role that was never
+  implemented: flag off, every handler raises `NotImplementedError`, a queue
+  is bound for nothing. Remove it or build it; today it's noise.
+- `check_url_match()` — declared on every handler, never called.
+- The commented-out `StructuredLoggingFormatter` in `application/loggers.py`
+  — either wire it to a flag or drop it.
 
-### Works today
-- End-to-end happy path for **Liked Songs at `DEPTH_OF_SEARCH = 1`**: crawl → cache to disk → build the Neo4j graph.
-- Four implemented + wired handlers: `GetSingleTrack`, `GetSingleArtist`, `GetSingleAlbum`, `LikedSongsPlaylist`.
-- Retry/backoff for HTTP 429 and 500; pagination via the `next` link.
-- One-time OAuth (Authorization Code grant) via a small Falcon web service.
+## History (compressed)
 
-### Broken / unfinished
-- **Four stub handlers** (crash with `KeyError` if reached):
-  - `me/my_followed_playlists.py` — `# TODO: implement`
-  - `me/my_followed_artists.py` — `# TODO: implement`
-  - `artists/albums_of_artist.py` — `# FIXME`, no class
-  - `albums/tracks_of_album.py` — `# FIXME`, no class
-  - The `DEPTH_OF_SEARCH = 1` ceiling is the only thing keeping these off the execution path.
-- **`write_to_sqlite` is `NotImplementedError` everywhere** (flag is off — leave it off).
-
-### Known bugs
-- ✅ **Token-refresh bug (`api_call_engine.py`)** — _fixed (Stage 1)._ `SPOTIFY_API_TOKEN` was read once at import and never updated after a 401 refresh → infinite refresh loop past the ~1h token. Now re-read from disk via `load_api_token()` after `refresh_spotify_auth()`.
-- ✅ **Inverted 429 backoff (`api_call_engine.py`)** — _fixed (Stage 1)._ `sleep(max(Retry-After, 600))` floored the wait at 10 min and obeyed punitive values in full (a live crawl got a ~24h `Retry-After` and froze). Now `min(Retry-After, 600)`.
-
-### Notable gaps
-- **No UX / data viz.** The only way to see the graph is the Neo4j browser + hand-written Cypher. `pandas`/`jupyter`/`openpyxl` are dependencies but effectively unused.
-- **No cloud / CI.** Local Docker Compose only; no Terraform/k8s/GitHub Actions. Compose currently hard-codes absolute `/Users/michael/...` mount paths.
-
----
-
-## 3. Roadmap
-
-### Stage 0 — Reproducible one-command run _(in progress)_
-**Goal:** `docker compose up` brings up the entire system, including the auth flow, with no manual host-side steps.
-- [x] Bundle the Spotify auth web service into Docker Compose (port 8000).
-- [x] Gate the pipeline on auth completion via a token healthcheck (one `up`, waits for the human to authorize, then proceeds).
-- [x] Point the pipeline at **Neo4j Desktop on the host** (`host.docker.internal:7687`) instead of the containerized Neo4j (which collides on port 7687).
-- [x] Replace hard-coded `/Users/michael/...` mount paths with relative `./secrets` / `./data` paths for portability.
-- [x] Add a `build:` context so `docker compose up --build` produces the image.
-
-**Verified end-to-end on 2026-06-21:** one `docker compose up` → bundled OAuth (now `http://127.0.0.1:8000/callback` — Spotify rejects `localhost` as insecure) → crawl → Neo4j. The first live crawl also surfaced the rate-limit failure mode that motivated Stage 1.
-
-### Stage 1 — Correctness, dedup & batch endpoints _(the branch's namesake)_
-**What set the priorities:** the first live crawl (depth 1, ~12k Liked Songs) flooded Spotify with redundant per-song follow requests (no dedup) and got the app **rate-limited with a ~24h `Retry-After`**, which the inverted 429 sleep then obeyed in full. Dedup + the two bug fixes address this head-on.
-
-- [x] **Fix the token-refresh bug** — re-read the token after a 401 refresh.
-- [x] **Cap the 429 backoff** at 10 min (`max`→`min`) so a punitive `Retry-After` can't freeze the worker.
-- [x] **Redis crawled-URL dedup** — durable Redis service (AOF + named volume); one persistent `spb:crawled_urls` set; `SADD`-skip at the `request_url` choke point (`CRAWLED_URL_DEDUP`, default on); `RESET_CRAWL` for a fresh crawl. The fix for the request flood.
-- [x] **Batch endpoints behind a feature flag** (`USE_BATCH_ENDPOINTS`, **default off**) — `request_batch` (chunked `?ids=`, caps 50/20/50) + "Get Several" handlers + `UNWIND` Cypher + dispatcher routing + `follow_links` branch. A 20-song page → 3 calls instead of ~67 (~22× fewer at 12k scale).
-- [x] **Live-verify batch access** — verified **2026-07-06** post-cooldown: the `?ids=` batch endpoints for tracks/albums/artists all return `200` for this app, so live crawls now run with `USE_BATCH_ENDPOINTS=true`. _Spotify only **postponed** removing them, so the per-item fallback (flag off) stays._
-- [ ] _(later)_ Cross-response Neo4j batching (buffer N / flush on interval) — secondary; the API-call batching above is the bigger win.
-- [ ] _(later)_ Remove the dead `check_url_match()` stubs.
-
-### Stage 2 — Deeper crawls
-**Goal:** crawl beyond Liked Songs at depth 1.
-- [ ] Implement the four stub handlers (`followed_playlists`, `followed_artists`, `albums_of_artist`, `tracks_of_album`).
-- [ ] Validate `DEPTH_OF_SEARCH > 1` doesn't explode rate limits; tune backoff.
-- [ ] Add basic crawl observability (counts, progress, dead-letter for unroutable responses).
-
-### Stage 3 — Visualization / UX
-**Goal:** actually *browse* your taste graph — the "power browser" promise.
-- [ ] Stand up a read API or notebook over the graph.
-- [ ] Build a graph-explorer UI (e.g. force-directed view of artists/albums/genres, filters by popularity/genre/era).
-
-### Stage 4 — Multi-user & overlap
-**Goal:** "here's my graph, here's my friend's — merge and explore the overlap."
-- [ ] Schema change: make ownership a **relationship**, not a node property — introduce `(:User)-[:LIKED {added_at}]->(:Track)` instead of `liked_songs`/`date_added_to_liked_songs` on the node. Overlap = tracks with `LIKED` edges from ≥2 users.
-- [ ] Per-user token storage (DB, not fixed `secrets/*.secret` files).
-- [ ] Add an OAuth `state` parameter to identify the user through the round-trip (also closes the current CSRF gap).
-- [ ] Overlap/diff queries + visualizations (shared artists, divergent genres, Jaccard similarity).
-
-### Stage 5 — Cloud (optional / later)
-- [ ] Parameterize config via env vars; remove machine-specific paths.
-- [ ] CI (build + lint + smoke test).
-- [ ] Deploy target (managed RabbitMQ + Neo4j Aura + container host).
-
-### Stage 6 — Mock Spotify service (testing + AWS) _(planned)_
-A controllable facade of the Spotify API that can inject rate limiting / failures
-between successful fetches. Unlocks the resilience + E2E + scale tests that
-fixtures can't reach (the 429-cap, token-refresh, and dedup-rollback-on-500
-paths), and doubles as a first AWS workload that informs the real migration.
-**Design + phased plan: [docs/mock-spotify-service.md](docs/mock-spotify-service.md).**
-- [ ] Phase 0: configurable Spotify base URLs (env-overridable; mock emits self-referential hrefs).
-- [ ] Phase 1: local FastAPI mock + deterministic catalog as a Compose service; E2E / pagination / scale tests.
-- [ ] Phase 2: failure-injection control plane; the resilience tests.
-- [ ] Phase 3+: deploy to Fargate; inform the real-app AWS migration.
-
----
-
-## 4. File map
-
-| Area | Path |
-|------|------|
-| Feature flags / crawl config | `application/config.py` |
-| Crawl seeding | `application/requests_factory.py` |
-| API engine (HTTP + fan-out) | `application/api_call_engine.py` |
-| OAuth web service | `application/spotify_authentication/api_authorization_web_service.py` |
-| Token refresh | `application/spotify_authentication/refresh_token.py` |
-| Message queue helpers | `application/message_queue/` |
-| Graph connection + queries | `application/graph_database/` |
-| Response handlers (one per endpoint) | `application/response_handlers/` |
-| Orchestration | `compose.yaml`, `Dockerfile` |
+Stages 0–1 of the original roadmap (one-command run; dedup + batch endpoints
++ the 429/token-refresh bug fixes) completed 2026-06/07 and are described
+above. The original Stage 2–6 sketches were superseded by the numbered plans
+in [docs/plans/](docs/plans/README.md) — each plan says what it supersedes.
+Two live-crawl war stories worth remembering when touching the engine: a
+punitive 24-hour `Retry-After` once froze the crawl (hence the 10-minute
+backoff cap), and an exclusive/auto-delete queue once discarded ~950 queued
+requests on a reconnect (hence durable named queues everywhere).

--- a/application/README.md
+++ b/application/README.md
@@ -1,0 +1,33 @@
+# application/ — the pipeline
+
+Everything the Docker Compose services actually run. The big picture (with
+diagrams) is in [docs/architecture.md](../docs/architecture.md); this is the
+door-by-door tour.
+
+## The five files/folders that ARE the crawler
+
+| Path | Role | Runs as |
+|---|---|---|
+| [config.py](config.py) | Every setting and feature flag, all env-overridable | imported everywhere |
+| [requests_factory.py](requests_factory.py) | Seeds a crawl; the single choke point (`request_url`) every outbound URL passes through, where Redis dedup happens | `requests_factory_start_crawls` service |
+| [api_call_engine.py](api_call_engine.py) | The only code that talks HTTP to Spotify: GETs, 429 backoff (capped 10 min), 500 retries, 401 token refresh, pagination | `api_call_engine` service |
+| [response_handlers/](response_handlers/) | One class per Spotify endpoint; workers dispatch each response to the right one | the three `responses_*` services |
+| [message_queue/](message_queue/) + [cache/](cache/) | RabbitMQ and Redis plumbing | imported by the above |
+
+## The supporting cast
+
+| Path | What it's for |
+|---|---|
+| [spotify_authentication/](spotify_authentication/) | OAuth login web app + token storage + refresh ([docs/auth.md](../docs/auth.md)) |
+| [graph_database/](graph_database/) | Neo4j connection, all Cypher queries, migrations ([docs/data-model.md](../docs/data-model.md)) |
+| [discovery/](discovery/) | Artist popularity/followers backfill (post-crawl enrichment) |
+| [mastering/](mastering/) | Rolls duplicate releases into canonical Songs (post-crawl batch job) |
+| [annotations/](annotations/) | Timestamped notes/cues/sections on tracks (interactive CLIs) |
+| [playlists/](playlists/) | Writes graph-derived playlists back to Spotify (guarded, dry-run default) |
+| [loggers.py](loggers.py) | Plain-text logging to stdout (a JSON formatter exists but is off) |
+
+## How a change here reaches a running system
+
+All of this is baked into the one shared Docker image, so:
+`docker compose build && docker compose up`. Nothing is volume-mounted at
+runtime except `secrets/`, `data/`, `tests/`, and `mock_spotify/`.

--- a/application/annotations/README.md
+++ b/application/annotations/README.md
@@ -1,0 +1,51 @@
+# annotations/ — timestamped notes on your music
+
+Turn listening into data: attach notes, cue points, and section maps
+(intro/buildup/drop/…) to tracks in the graph, either from your keyboard
+after the fact or live while the music plays.
+
+## Two ways in
+
+**Cold entry** — search the graph by name, annotate from prompts:
+
+```bash
+docker compose run --rm responses_write_to_neo4j \
+    python3 -m application.annotations.annotate "silver soul"
+```
+
+**Live capture** — start playback anywhere (phone, desktop), keep this
+terminal focused, tap keys as the song plays:
+
+```bash
+docker compose run --rm responses_write_to_neo4j \
+    python3 -m application.annotations.listen
+```
+
+| Key | Action |
+|---|---|
+| `n` | note at the current position (prompts for text) |
+| `c` | cue point (prompts for a label — "drop", "sax comes in") |
+| `s` | section boundary (label → kind is inferred: "Buildup 2" → `buildup`) |
+| `u` | undo the last capture |
+| `+` / `-` | nudge the last capture ±500 ms |
+| `q` | quit and print the session summary |
+
+Live capture polls `GET /v1/me/player` about once a second, so positions are
+accurate to ~1–2 s — nudge if it matters. It needs the
+`user-read-playback-state` scope (part of the standard bundled login,
+[docs/auth.md](../../docs/auth.md)); against the mock
+(`-e SPOTIFY_API_BASE_URL=http://spotify_mock`) no real account is needed.
+
+## What lands in the graph
+
+`(:Track)-[:HAS_NOTE|HAS_CUE|HAS_SECTION]->` nodes; Sections additionally
+chain via `NEXT` edges kept in start-time order even when you mark boundaries
+out of order. Tracks must already exist in the graph — inserts `MATCH`, never
+create. Model and invariants: [model.py](model.py), Cypher in
+[queries/annotations/](../graph_database/queries/annotations/), story in
+[docs/data-model.md](../../docs/data-model.md#story-4-a-listening-session-leaves-a-trail-annotations).
+
+[timecode.py](timecode.py) parses positions (`1:23`, `83`, `41000ms`).
+
+Plan 04's later phases (DJ set planning, playback HUD) are designed but not
+built — see [docs/plans/04-annotations-and-dj-sets.md](../../docs/plans/04-annotations-and-dj-sets.md).

--- a/application/api_call_engine.py
+++ b/application/api_call_engine.py
@@ -273,13 +273,9 @@ def make_spotify_api_call(ch, method, properties, body):
 
 
 def entrypoint():
-    # The full setup (connect -> bind -> consume) lives INSIDE the loop so a
-    # closed channel/connection — an unhandled callback error, a broker
-    # restart, a heartbeat timeout — is recovered by RECONNECTING. The previous
-    # version set up once outside the loop and re-called start_consuming() on
-    # the already-closed channel, hot-spinning forever ("Channel is closed.")
-    # while every published request drained into the void. The sleep bounds the
-    # retry rate when the broker is unreachable.
+    # Setup (connect -> bind -> consume) must live INSIDE the loop: recovery
+    # from a closed channel/connection means reconnecting, not re-consuming
+    # (regression: tests/test_engine_consumer_resilience.py).
     while True:
         try:
             connection, channel = connect_to_rabbitmq_exchange(

--- a/application/cache/README.md
+++ b/application/cache/README.md
@@ -1,0 +1,25 @@
+# cache/ — Redis client (crawl memory + login nonces)
+
+One module, [redis_client.py](redis_client.py), two unrelated jobs that both
+happen to need Redis:
+
+**1. Crawled-URL dedup** — the reason a 12k-track library doesn't become a
+million requests. Every outbound URL is `SADD`ed to a set *at publish time*
+(so two workers queuing the same URL in the same second collapse to one
+fetch); members are keyed `"{depth}|{url}"` so a URL seen at depth 0 can
+still be re-fetched later at a deeper depth. Two sets exist:
+
+- `spb:crawled_urls` — the shared catalog (tracks/albums/artists are the same
+  for everyone)
+- `spb:crawled_urls:<user_id>` — per-user, for `/v1/me/*` URLs (your Liked
+  Songs page 2 is not your friend's)
+
+`unmark_url()` is the rollback used when a fetch permanently fails — without
+it a failed URL would be remembered as "done" and silently lost.
+`RESET_CRAWL` / `RESET_CRAWL_CATALOG` clear the user set / shared set
+respectively. The set survives restarts (Redis AOF + named volume) — that
+persistence is a feature, not an accident.
+
+**2. OAuth state nonces** — `store_oauth_state()` / `consume_oauth_state()`
+(atomic `GETDEL`, 10-minute TTL) back the login flow's CSRF protection. See
+[docs/auth.md](../../docs/auth.md).

--- a/application/config.py
+++ b/application/config.py
@@ -58,7 +58,7 @@ CRAWLED_URL_DEDUP = _env_bool('CRAWLED_URL_DEDUP', True)
 # Use Spotify's multi-id batch endpoints (GET /v1/{type}?ids=) when fetching
 # tracks/albums/artists. Default OFF: existing apps currently RETAIN batch access,
 # but Spotify only POSTPONED (did not cancel) removing it, and access can only be
-# live-verified via application/_probe_batch_endpoints.py once the rate limit
+# live-verified via scripts/probes/probe_batch_endpoints.py once the rate limit
 # clears. Flip on via env (USE_BATCH_ENDPOINTS=true) after probing.
 USE_BATCH_ENDPOINTS = _env_bool('USE_BATCH_ENDPOINTS', False)
 

--- a/application/discovery/README.md
+++ b/application/discovery/README.md
@@ -1,0 +1,22 @@
+# discovery/ — artist enrichment backfill
+
+One job: fill in `popularity` and `followers` on Artist nodes after a crawl,
+because discovery ranking ("show me *obscure* adjacent artists") needs those
+numbers and the crawl's simplified artist objects don't carry them.
+
+```bash
+docker compose run --rm responses_write_to_neo4j \
+    python3 -m application.discovery.backfill_artists
+```
+
+[backfill_artists.py](backfill_artists.py) finds Artists missing `popularity`,
+batch-fetches them 50 at a time via `/v1/artists?ids=` (with the same
+429/500 patience as the crawl engine), and updates the nodes in place.
+~7,600 artists ≈ 152 API calls, a few minutes.
+
+Note the *seeding* side of discovery — deciding which artists deserve a
+discography crawl — lives in
+[requests_factory.py](../requests_factory.py) behind the
+`CRAWL_ARTIST_DISCOGRAPHIES` flag, and the crawl itself is ordinary pipeline
+work. This folder is only the enrichment step. The end-to-end feature is
+described in [docs/plans/01-adjacent-artist-discovery.md](../../docs/plans/01-adjacent-artist-discovery.md).

--- a/application/graph_database/README.md
+++ b/application/graph_database/README.md
@@ -1,0 +1,41 @@
+# graph_database/ — Neo4j connection, queries, migrations
+
+Everything Cypher lives here, as `.cypher` files (or `.jinja` templates)
+rather than strings in Python — so queries are readable, diffable, and
+reusable in the Neo4j browser. What the data *means* is told in
+[docs/data-model.md](../../docs/data-model.md).
+
+| Path | What's in it |
+|---|---|
+| [connect.py](connect.py) | Driver setup; credentials from `secrets/neo4j_credentials.yaml`; hostname from `NEO4J_HOSTNAME` (in Docker: `host.docker.internal` → your Neo4j Desktop) |
+| [initialize_database_environment.py](initialize_database_environment.py) | Applies the uniqueness constraints at startup |
+| [queries/](queries/) (root) | The crawl's insert queries: single and batch variants for tracks/albums/artists/liked-songs |
+| [queries/discovery/](queries/discovery/) | Discography-seed selection + album/track inserts for the adjacent-artist crawl |
+| [queries/mastering/](queries/mastering/) | Song cluster merges, `REMIX_OF` edges, ISRC backfill fetches |
+| [queries/overlap/](queries/overlap/) | The two-user comparison pack — see the [guided tour](../../docs/exploring-the-graph.md#the-shared-music-space-when-a-friends-library-is-loaded) |
+| [queries/annotations/](queries/annotations/) | Note/Cue/Section inserts, the `NEXT`-chain maintenance, undo/nudge |
+| [queries/playlists/](queries/playlists/) | ManagedPlaylist bookkeeping + the playlist generators' source queries |
+| [migrations/](migrations/) | Numbered `.cypher` migrations + [run.py](migrations/run.py), the runner |
+
+## Conventions
+
+- **MERGE on stable IDs, never CREATE** — re-crawling is idempotent by
+  construction.
+- **Ownership on edges, not node properties** — `(:User)-[:LIKED]->(:Track)`;
+  catalog nodes stay shared (established by migration 0001).
+- **`WITH` between `MERGE` and any `CALL {}` subquery** — Neo4j 5.26-line
+  servers reject the shorthand that Desktop tolerates (learned in PR #18).
+
+## Migrations
+
+```bash
+python3 -m application.graph_database.migrations.run 0001_multiplayer_ownership \
+    --me <your_spotify_user_id> --display-name "You"
+```
+
+Each migration runs in one transaction. `run.py` refuses migrations whose
+header says `DO NOT RUN` (that's [0002](migrations/0002_drop_legacy_liked_props.cypher),
+the legacy-property cleanup, held back until the multiplayer rollback window
+closes) and refuses 0001 on a graph that already has another user's data.
+There is no applied-migrations table — with two migrations, idempotence +
+guards stand in for one.

--- a/application/mastering/README.md
+++ b/application/mastering/README.md
@@ -1,0 +1,57 @@
+# mastering/ — one Song, many releases
+
+Your library contains the same recording under several names — album cut,
+radio edit, deluxe re-release, "2011 Remaster". Mastering rolls those up into
+canonical `(:Song)` nodes so counting and exploring work at the level you
+actually think in, without deleting any release-level truth.
+
+## The workflow
+
+```bash
+# 1. (first time only) fetch missing ISRCs — the recording industry's serial numbers
+python -m application.mastering.backfill
+
+# 2. run the clustering job (idempotent; re-run after every crawl)
+python -m application.mastering.run
+
+# 3. read the review report
+open data/mastering_review.md
+
+# 4. fix any wrong merges/splits, then re-run step 2
+$EDITOR secrets/mastering_overrides.yaml     # format: overrides.example.yaml
+```
+
+## How it decides two Tracks are the same Song
+
+Strongest evidence wins, and your overrides beat everything:
+
+1. **ISRC match** ([cluster.py](cluster.py)) — same serial number, same
+   recording. Confidence 1.0.
+2. **Spotify `linked_from`** — Spotify's own market-relinking. 0.95.
+3. **Heuristic** — same normalized title + same primary artist + duration
+   within 3 s. 0.85. Title normalization ([normalize.py](normalize.py)) strips
+   suffixes like "– 2011 Remaster" / "(Deluxe)" and records what it stripped
+   as the version `kind`.
+4. **Manual overrides** ([overrides.py](overrides.py)) — forced merges and
+   splits from `secrets/mastering_overrides.yaml`.
+
+Two deliberate stances: **remix credits are never stripped** — a remix is a
+different song, so it becomes its own Song with a `REMIX_OF` edge to the
+parent; and **re-recordings ("Taylor's Version") stay separate Songs** — they
+are different recordings, and that's the point of them.
+
+## What it writes
+
+`(:Song {id, title})` nodes (id = ISRC when unambiguous, else a stable hash),
+exactly one `(:Track)-[:VERSION_OF {kind, method, confidence}]->(:Song)` per
+Track, and `(:Song)-[:REMIX_OF]->(:Song)` edges. Re-runs re-point edges;
+nothing is ever deleted. The graph shape is illustrated in
+[docs/data-model.md](../../docs/data-model.md#story-2-five-releases-one-song-mastering).
+
+[report.py](report.py) writes `data/mastering_review.md` after every run,
+most-ambiguous clusters first — the human feedback loop that keeps the
+heuristics honest.
+
+Tests: `test_mastering_normalize.py` (the suffix rules, effectively the
+spec), `test_mastering_clustering.py`, `test_mastering_overrides.py`,
+`test_mastering_e2e.py`.

--- a/application/message_queue/README.md
+++ b/application/message_queue/README.md
@@ -1,0 +1,19 @@
+# message_queue/ — RabbitMQ plumbing
+
+Thin helpers over [pika](https://pika.readthedocs.io/), shared by every
+service that touches the broker.
+
+- [constants.py](constants.py) — the topology, in one place: the
+  `spotify_api_requests` exchange (routing key `make_api_call`) and the
+  `spotify_api_responses` exchange (routing keys `write_to_disk`,
+  `write_to_neo4j`, `follow_links`, plus the unused `write_to_sqlite`). Both
+  are `direct` exchanges.
+- [connect.py](connect.py) — connect (600 s heartbeat, tuned so a slow
+  fetch-and-fan-out callback doesn't get the connection reaped), declare
+  exchanges, bind queues, publish persistent messages.
+
+The one hard-won rule encoded here: **work queues are named, durable, and
+non-exclusive.** An exclusive/auto-delete queue vanishes when its consumer
+disconnects — which once silently discarded ~950 queued requests when the
+engine reconnected mid-crawl (fixed in PR #26, regression-tested in
+`tests/test_engine_consumer_resilience.py`).

--- a/application/message_queue/connect.py
+++ b/application/message_queue/connect.py
@@ -58,11 +58,9 @@ def bind_queue_to_exchange(
     :return: the name of the queue as a string
     """
 
-    # A NAMED queue is a shared, durable work queue (make_api_call, the response
-    # topics): it must NOT be tied to the declaring connection, or a single
-    # consumer's dropped connection deletes the queue and every request still
-    # sitting in it (the discography-crawl failure: an engine reconnect wiped
-    # ~950 queued album-batch/frontier-sweep requests). An UNNAMED queue is a
+    # A NAMED queue is a shared durable work queue and must NOT be tied to the
+    # declaring connection, or one consumer's drop deletes the queue and its
+    # backlog (see application/message_queue/README.md). An UNNAMED queue is a
     # throwaway reply queue and stays exclusive/auto-deleting.
     is_named = queue_name is not None
     result = channel.queue_declare(

--- a/application/playlists/README.md
+++ b/application/playlists/README.md
@@ -1,0 +1,50 @@
+# playlists/ — the graph writes back to Spotify
+
+Everything else in this project reads from Spotify. This module is the one
+place that writes — it turns graph queries into real playlists in your
+Spotify client, under strict guardrails.
+
+## Using it
+
+```bash
+# See what would change (dry-run is the default — nothing is written)
+python3 -m application.playlists.sync adjacent-discoveries
+
+# Actually do it
+python3 -m application.playlists.sync adjacent-discoveries --apply
+
+# Other generators
+python3 -m application.playlists.sync exploration-queue "Floating Points" --apply
+python3 -m application.playlists.sync blend <user_a> <user_b> --apply
+```
+
+| Generator | Playlist it maintains | Needs |
+|---|---|---|
+| `adjacent-discoveries` | Unknown artists adjacent to your taste (bridges-ranked, popularity-capped) | a discography crawl |
+| `exploration-queue <artist>` | That artist's albums you haven't explored, flattened in release order | a discography crawl |
+| `blend <a> <b>` | Tracks new to both users but adjacent to both tastes | two crawled users |
+| `time-capsule <year>` | Songs you liked that year | plan 09 (not yet) |
+
+## The safety model (worth trusting)
+
+- **Dry-run by default.** `--apply` is always an explicit choice.
+- **Managed-only writes.** Every playlist this system creates is recorded as
+  a `(:ManagedPlaylist)` node; before any Spotify write the code checks the
+  target is on that list and refuses otherwise. It is structurally unable to
+  touch a playlist you made by hand.
+- **Diff, don't rebuild.** Sync computes adds/removes against the current
+  state (chunked ≤100 per request, Spotify's cap) instead of wiping and
+  rewriting; a full rewrite happens only when order matters and has drifted.
+- **Snapshots.** The last three intended track lists are stored on the node
+  (`target_snapshots`) so a bad generator run can be rolled back.
+- Playlists are created private, named `[SPB] …`, with a "do not edit"
+  description — clearly machine-owned in your client.
+
+Files: [generators.py](generators.py) (the registry — a generator is a Cypher
+query + identity params, hashed so the same inputs always map to the same
+playlist), [sync.py](sync.py) (diff + apply + refresh-on-401),
+[model.py](model.py) (the ManagedPlaylist node builders). Requires the
+`playlist-modify-private` scope ([docs/auth.md](../../docs/auth.md)).
+
+Tests: `test_playlist_generators.py`, `test_playlist_sync.py`,
+`test_playlist_mock.py` (full CRUD against the mock).

--- a/application/response_handlers/README.md
+++ b/application/response_handlers/README.md
@@ -1,0 +1,39 @@
+# response_handlers/ — one class per Spotify endpoint
+
+When a Spotify response comes off the queue, exactly one handler class knows
+what to do with it. A handler answers three questions about its endpoint:
+*where does this go on disk*, *which Cypher writes it to the graph*, and
+*which links inside it are worth crawling next*.
+
+## How dispatch works
+
+[main.py](main.py) is the worker entry point
+(`python3 main.py write_to_disk|write_to_neo4j|follow_links`). Its
+`SpotifyResponseController.resolve_handler(url)` maps a URL to a class:
+
+| URL shape | Handler | Notes |
+|---|---|---|
+| `/v1/me/tracks` | [me/my_liked_songs.py](me/my_liked_songs.py) `LikedSongsPlaylist…` | The crawl's usual starting point; writes `LIKED` edges per user |
+| `/v1/tracks/{id}`, `/v1/albums/{id}`, `/v1/artists/{id}` | [tracks/single_track.py](tracks/single_track.py), [albums/single_album.py](albums/single_album.py), [artists/single_artist.py](artists/single_artist.py) | The per-item path (`USE_BATCH_ENDPOINTS=false`) |
+| `/v1/tracks?ids=…`, `/v1/albums?ids=…`, `/v1/artists?ids=…` | [tracks/several_tracks.py](tracks/several_tracks.py), [albums/several_albums.py](albums/several_albums.py), [artists/several_artists.py](artists/several_artists.py) | The batch path (~22× fewer API calls) |
+| `/v1/artists/{id}/albums` | [artists/albums_of_artist.py](artists/albums_of_artist.py) | Discography crawl: harvests album IDs, defers content to the batch handler |
+| `/v1/albums/{id}/tracks` | [albums/tracks_of_album.py](albums/tracks_of_album.py) | Only for albums with >50 tracks (paginated track lists) |
+| `/v1/me/playlists`, `/v1/me/following` | [me/my_followed_playlists.py](me/my_followed_playlists.py), [me/my_followed_artists.py](me/my_followed_artists.py) | **Not implemented** — placeholders for plan 02 |
+
+[base_handler.py](base_handler.py) defines the interface;
+[batch_handler.py](batch_handler.py) adds shared logic for the `?ids=`
+endpoints (chunking, per-item disk writes, frontier-artist sweeps).
+
+## Depth, in one paragraph
+
+Every message carries `depth_of_search`. Handlers re-queue *neighbors* (albums,
+artists found inside a response) at **depth − 1**; pagination (`next` links)
+continues at the **same** depth because page 2 is the same resource, not a
+hop. Depth 0 means "persist this, follow nothing." The discography crawl
+seeds at depth 2 → albums fetched at depth 1 → collaborating "frontier"
+artists enriched at depth 0, and nothing on that path ever emits another
+discography URL — that invariant is what keeps the crawl finite. See
+[docs/architecture.md](../../docs/architecture.md#level-3-inside-the-pipeline).
+
+`write_to_sqlite()` on every handler is an unimplemented stub from the early
+days (flag off; see ROADMAP).

--- a/application/response_handlers/albums/single_album.py
+++ b/application/response_handlers/albums/single_album.py
@@ -24,9 +24,6 @@ class GetSingleAlbumResponseHandler(BaseResponseHandler):
     def __init__(self, request_url, depth_of_search, response, user_id=None):
         super().__init__(request_url, depth_of_search, response, user_id=user_id)
 
-    def check_url_match(self, url):
-        return False  # TODO
-
     def write_to_disk(self):
         output_file = self.DISK_LOCATION / f"album_{self.clean_name}.json"
         super()._write_to_disk(output_path=output_file)

--- a/application/response_handlers/albums/tracks_of_album.py
+++ b/application/response_handlers/albums/tracks_of_album.py
@@ -15,19 +15,11 @@ class GetTracksOfAlbumResponseHandler(BaseResponseHandler):
     """Get Album Tracks: GET /v1/albums/{id}/tracks (plan 01 T6).
     Docs: https://developer.spotify.com/documentation/web-api/reference/get-an-albums-tracks
 
-    Only reached for albums whose track list paginates past the 50 tracks a
-    batch-album response embeds: GetSeveralAlbumsResponseHandler follows the
-    nested album.tracks.next when present (rare -- long compilations and
-    deluxe boxes), and the api_call_engine keeps following this page's own
-    "next" at the same depth until pagination ends.
-
-    Depth semantics: pages arrive at the depth of the batch-album response
-    that spawned them (pagination is a continuation, not a hop, so the
-    spawning handler enqueues them even at depth 0). At depth >= 1,
-    follow_links batches this page's track credits at depth-1 for frontier
-    enrichment; at depth 0 the page is still persisted (write_to_neo4j runs
-    unconditionally -- no silent truncation of >50-track albums) but the
-    credits hop ends here.
+    Only reached for albums whose track list paginates past the 50 embedded
+    tracks of a batch-album response (long compilations, deluxe boxes).
+    Pagination continues at the SAME depth (a continuation, not a hop), and
+    the page is persisted even at depth 0 — no silent truncation of >50-track
+    albums. Depth rules: application/response_handlers/README.md.
     """
 
     URL_PATTERN = f"{SPOTIFY_API_BASE_URL}/v1/albums/{{album_id}}/tracks"
@@ -47,9 +39,6 @@ class GetTracksOfAlbumResponseHandler(BaseResponseHandler):
     @property
     def name(self):
         return f"tracks_of_album_{self.album_id}_{self.response.get('offset', 0)}"
-
-    def check_url_match(self, url):
-        return False  # sub-resource routing is by path segments in the dispatcher
 
     def write_to_disk(self):
         output_file = self.DISK_LOCATION / f"{self.clean_name}.json"

--- a/application/response_handlers/artists/albums_of_artist.py
+++ b/application/response_handlers/artists/albums_of_artist.py
@@ -12,19 +12,11 @@ class GetAlbumsOfArtistResponseHandler(BaseResponseHandler):
     """Get Artist's Albums: GET /v1/artists/{id}/albums (plan 01 T5).
     Docs: https://developer.spotify.com/documentation/web-api/reference/get-an-artists-albums
 
-    An album-id harvest, not a resource in itself: the response carries
-    simplified album objects, so follow_links batches the ids through
-    /v1/albums?ids= (chunks of 20 via the request_batch machinery) and the
-    full objects -- embedded track lists included -- are written to Neo4j by
-    GetSeveralAlbumsResponseHandler. Page-level pagination ("next") is
-    re-queued by the api_call_engine at the same depth, like every handler.
-
-    Depth semantics (plan 01, no unbounded recursion): discography seeds are
-    published at depth 2 (see SpotifyRequestFactory.DISCOGRAPHY_SEED_DEPTH),
-    so the album batches leave here at depth 1 -- deep enough for the batch
-    handler to run the frontier artist sweep (depth 0, terminal), and no
-    deeper. Nothing on this path ever publishes another /v1/artists/{id}/albums
-    URL, so a frontier artist's own discography is never crawled.
+    An album-id harvest: follow_links batches the ids through /v1/albums?ids=
+    and the full objects are written by GetSeveralAlbumsResponseHandler.
+    Invariant: only the discography seeder publishes this URL shape, so a
+    frontier artist's own discography is never crawled — depth chain and
+    rationale in application/response_handlers/README.md.
     """
 
     URL_PATTERN = f"{SPOTIFY_API_BASE_URL}/v1/artists/{{artist_id}}/albums"
@@ -41,9 +33,6 @@ class GetAlbumsOfArtistResponseHandler(BaseResponseHandler):
     @property
     def name(self):
         return f"albums_of_artist_{self.artist_id}_{self.response.get('offset', 0)}"
-
-    def check_url_match(self, url):
-        return False  # sub-resource routing is by path segments in the dispatcher
 
     def write_to_disk(self):
         output_file = self.DISK_LOCATION / f"{self.clean_name}.json"

--- a/application/response_handlers/artists/single_artist.py
+++ b/application/response_handlers/artists/single_artist.py
@@ -23,9 +23,6 @@ class GetSingleArtistResponseHandler(BaseResponseHandler):
     def __init__(self, request_url, depth_of_search, response, user_id=None):
         super().__init__(request_url, depth_of_search, response, user_id=user_id)
 
-    def check_url_match(self, url):
-        return False  # TODO
-
     def write_to_disk(self):
         output_file = self.DISK_LOCATION / f"artist_{self.clean_name}.json"
         super()._write_to_disk(output_path=output_file)

--- a/application/response_handlers/base_handler.py
+++ b/application/response_handlers/base_handler.py
@@ -27,10 +27,6 @@ class BaseResponseHandler(ABC):
         return self.name.replace("/", "_slash_").replace("\\", "_back_slash_")
 
     @abstractmethod
-    def check_url_match(self, url):
-        pass
-
-    @abstractmethod
     def write_to_disk(self):
         pass
 

--- a/application/response_handlers/batch_handler.py
+++ b/application/response_handlers/batch_handler.py
@@ -30,9 +30,6 @@ class SeveralResourcesResponseHandler(BaseResponseHandler):
         """The resolved (non-null) objects from the batch response."""
         return [item for item in self.response[self.RESPONSE_KEY] if item is not None]
 
-    def check_url_match(self, url):
-        return False  # batch routing is by the ?ids= query param in the dispatcher
-
     def write_to_disk(self):
         for item in self.items:
             try:

--- a/application/response_handlers/me/my_liked_songs.py
+++ b/application/response_handlers/me/my_liked_songs.py
@@ -81,9 +81,6 @@ class LikedSongsPlaylistResponseHandler(BaseResponseHandler):
     def name(self):
         return f"liked_songs_{self.response['offset']}"
 
-    def check_url_match(self, url):
-        return False  # TODO
-
     def write_to_disk(self):
         # Multiplayer (plan 06): page filenames are keyed only by offset, so
         # each user's crawl archives under its own subdirectory — otherwise a

--- a/application/response_handlers/tracks/single_track.py
+++ b/application/response_handlers/tracks/single_track.py
@@ -24,9 +24,6 @@ class GetSingleTrackResponseHandler(BaseResponseHandler):
     def __init__(self, request_url, depth_of_search, response, user_id=None):
         super().__init__(request_url, depth_of_search, response, user_id=user_id)
 
-    def check_url_match(self, url):
-        return False  # TODO
-
     def write_to_disk(self):
         output_file = self.DISK_LOCATION / f"track_{self.clean_name}.json"
         super()._write_to_disk(output_path=output_file)

--- a/application/spotify_authentication/README.md
+++ b/application/spotify_authentication/README.md
@@ -1,0 +1,18 @@
+# spotify_authentication/ — OAuth login and token care
+
+The self-contained identity component: a small Falcon web app that turns a
+Spotify consent click into token files, plus the code that keeps those tokens
+fresh. **The full story — flow diagram, file layout, scopes, the primary-user
+mirror, extraction-as-a-library notes — is in [docs/auth.md](../../docs/auth.md).**
+
+| File | Job |
+|---|---|
+| [api_authorization_web_service.py](api_authorization_web_service.py) | Serves `/login` (user list + "add a user"), `/login/start` (mints a single-use CSRF nonce into Redis, redirects to Spotify), `/callback` (validates the nonce, exchanges the code, asks `/v1/me` whose token it is, saves) |
+| [token_store.py](token_store.py) | All reads/writes of token files. Multi-user: `secrets/users/<id>/`; the first user to log in becomes the sticky **primary** and is mirrored to the legacy `secrets/spotify_*.secret` files (the compose healthcheck gate reads those) |
+| [refresh_token.py](refresh_token.py) | POSTs the refresh token with HTTP Basic client auth (required — omitting it was the ~1-hour crawl-death bug, PR #16); keeps primary/legacy copies in sync both directions |
+
+Consumed by exactly three production modules (`api_call_engine`,
+`playlists/sync`, `response_handlers/me/my_liked_songs`) — see
+[docs/auth.md](../../docs/auth.md#where-auth-touches-the-rest-of-the-codebase).
+
+Tests: `test_oauth_service.py`, `test_token_store.py`, `test_refresh_token.py`.

--- a/application/spotify_authentication/api_authorization_web_service.py
+++ b/application/spotify_authentication/api_authorization_web_service.py
@@ -117,11 +117,9 @@ class SpotifyLoginStartResource:
                                   "redirect_uri": SPOTIFY_REDIRECT_URI})
 
         authorization_code_uri = f'{SPOTIFY_ACCOUNTS_BASE_URL}/authorize?{query_params}'
-        # 303 See Other + Cache-Control: no-store — NEVER a 301. The Location
-        # embeds a single-use state nonce; a permanent redirect is heuristically
-        # cacheable, so the browser would replay the consumed nonce on the next
-        # "Add a user" click and the callback would reject every login from
-        # that browser until its cache was cleared.
+        # 303 + no-store, NEVER a cacheable 301: the Location embeds a
+        # single-use nonce, and a cached redirect would replay it on the next
+        # login attempt (docs/auth.md).
         raise falcon.HTTPSeeOther(authorization_code_uri,
                                   headers={"Cache-Control": "no-store"})
 

--- a/application/spotify_authentication/refresh_token.py
+++ b/application/spotify_authentication/refresh_token.py
@@ -64,12 +64,9 @@ def refresh_spotify_auth(user_id=None):
         with open(SPOTIFY_REFRESH_TOKEN_FILE, "w") as f:
             f.write(refresh_token)
 
-        # TWO-WAY mirror (the runbook documents primary <-> legacy as kept in
-        # sync "on every save/refresh"): the legacy refresh token IS the
-        # primary's, so when a legacy-path refresh rotates it, the primary's
-        # namespaced copies must follow — or a later per-user 401 for the
-        # primary replays the stale token and 400s (invalid_grant), wedging
-        # their crawl until a manual re-auth.
+        # Two-way mirror: the legacy refresh token IS the primary's, so their
+        # namespaced copies must follow or the primary's next per-user 401
+        # replays a stale token (invalid_grant). See docs/auth.md.
         primary = token_store.get_primary_user_id()
         if primary is not None:
             token_store.save_tokens(primary, access_token, refresh_token)

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,16 +1,8 @@
 name: spotify-power-browser
-# Per-worktree isolation (parallel Claude Code sessions share one Docker daemon):
-#   IMAGE_TAG            overrides the shared image tag       (default: latest)
-#   COMPOSE_PROJECT_NAME overrides the project name that namespaces containers,
-#                        networks and volumes                 (default: the name: above)
-# .claude/settings.json's SessionStart hook writes those into a gitignored .env
-# AND a gitignored compose.override.yaml (ports: !reset []) for worktrees under
-# .claude/worktrees/*, so their stacks never collide on the shared tag/project
-# and publish no host ports (5672/15672/8000) — the per-project network already
-# connects the services. The PRIMARY checkout gets neither file: shared
-# defaults, fixed localhost ports, warm redis_data. Live crawls (the real host
-# Neo4j graph + warm dedup cache) are singular: run them from the primary
-# checkout, one at a time.
+# IMAGE_TAG and COMPOSE_PROJECT_NAME are overridden per git worktree by a
+# hook-written .env, so parallel checkouts don't collide on one Docker daemon.
+# Live crawls run from the primary checkout only. Full story:
+# docs/delivery.md#parallel-checkouts-the-worktree-trick
 services:
   rabbitmq:
     image: "rabbitmq:4-management"
@@ -41,12 +33,10 @@ services:
       timeout: 5s
       retries: 20
 
-  # Neo4j runs on the host via Neo4j Desktop (bolt://host.docker.internal:7687),
-  # not as a container — a containerized instance would collide on port 7687
-  # with the running Desktop, and the Desktop gives persistence + a graph
-  # browser for inspecting results. To go fully in-Docker instead: quit Neo4j
-  # Desktop, uncomment this service, drop the NEO4J_HOSTNAME override on
-  # responses_write_to_neo4j, and set neo4j_credentials.yaml to match NEO4J_AUTH.
+  # Neo4j runs on the host via Neo4j Desktop, not as a container (port-7687
+  # collision + the Desktop's browser/persistence — docs/architecture.md).
+  # To go fully in-Docker: quit Desktop, uncomment this, drop the
+  # NEO4J_HOSTNAME override on responses_write_to_neo4j, match NEO4J_AUTH.
   #
   # neo4j:
   #   image: "neo4j:community"
@@ -83,16 +73,10 @@ services:
       REDIS_HOSTNAME: ${REDIS_HOSTNAME:-redis}
     command: python3 application/spotify_authentication/api_authorization_web_service.py
     healthcheck:
-      # Healthy only once the OAuth flow has written an access token. This
-      # gates the pipeline so a single `docker compose up` waits for the human
-      # to authorize before any crawling begins. The long start_period keeps the
-      # container in "starting" (not "unhealthy") while it waits for a human, so
-      # `docker compose up` won't abort the gated services if authorization takes
-      # a while; the first successful probe flips it healthy immediately.
-      #
-      # Plan 06 keeps this file as the PRIMARY user's mirror (token_store.py):
-      # the first account to authorize writes both secrets/users/<id>/ and this
-      # legacy path, so multi-user auth does not break the one-command `up`.
+      # The auth gate: healthy only once the OAuth flow has written a token,
+      # so one `docker compose up` waits for the human to authorize. The long
+      # start_period keeps it "starting" (not "unhealthy") meanwhile. The file
+      # checked is the primary user's legacy mirror — see docs/auth.md.
       test: ["CMD-SHELL", "test -s /src/secrets/spotify_api_token.secret"]
       interval: 5s
       timeout: 5s

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+# docs/ — start here
+
+Reading order for someone new to the project:
+
+1. **[architecture.md](architecture.md)** — how the pieces fit together
+   (C4-style, widest view first). Read this one first.
+2. **[data-model.md](data-model.md)** — what's in the graph, told through
+   five stories (a liked song's journey, mastering, multiplayer, annotations,
+   playlists).
+3. **[exploring-the-graph.md](exploring-the-graph.md)** — the hands-on
+   tutorial for when the crawl is done and you're staring at 12k tracks.
+
+Then, by topic:
+
+| Doc | Covers |
+|---|---|
+| [auth.md](auth.md) | The Spotify OAuth flow, token storage, refresh, scopes — and how it could be extracted as a standalone module |
+| [delivery.md](delivery.md) | The four ways to run the software, the one-image build, worktree isolation, the (absent) CI, the (planned) AWS path |
+| [observability.md](observability.md) | The five windows into a running crawl and how to interpret them; honest gaps |
+| [testing.md](testing.md) | The four test layers, safety rails, coverage gaps |
+| [multiplayer-runbook.md](multiplayer-runbook.md) | Step-by-step: adding a second person's library |
+| [mock-spotify-service.md](mock-spotify-service.md) | Design doc for the mock + the AWS strategy |
+| [diagrams/README.md](diagrams/README.md) | Index of every system diagram — Lucid and Mermaid twins, side by side |
+| [plans/](plans/README.md) | The nine feature plans (six shipped, three pending) and the verified Spotify API surface |
+
+Component-level detail lives next to the code — every folder has a README
+(indexed in [architecture.md](architecture.md#where-the-code-lives)).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,255 @@
+# Architecture: the big picture
+
+Spotify Power Browser copies your Spotify listening data into a graph database
+(Neo4j) so you can explore it — on your own, with a friend, or with an AI
+assistant. This document explains how the pieces fit together, starting from
+the widest view and zooming in. It follows the
+[C4 model](https://c4model.com/): **Level 1** shows the system in its world,
+**Level 2** shows the running containers, **Level 3** shows the moving parts
+inside the pipeline.
+
+Every diagram here also exists in Lucid — see
+[docs/diagrams/README.md](diagrams/README.md) for the side-by-side index.
+
+---
+
+## Level 1: The system in its world
+
+```mermaid
+flowchart TB
+    you(["🧑‍🎤 You<br/>(the tastemaker)"])
+    friend(["🧑‍🤝‍🧑 A friend<br/>(second user)"])
+    ai(["🤖 AI assistant<br/>Claude Desktop / Claude Code"])
+
+    subgraph machine ["💻 Your machine"]
+        spb["🐳 Spotify Power Browser<br/>Docker Compose stack:<br/>crawler pipeline + OAuth service"]
+        neo4j[("🕸️ Neo4j Desktop<br/>the taste graph")]
+        mcp["🔌 MCP server<br/>read-only graph access"]
+    end
+
+    spotify["🎵 Spotify Web API<br/>api.spotify.com<br/>accounts.spotify.com"]
+
+    you -- "logs in once, watches the crawl" --> spb
+    friend -- "logs in via /login (add a user)" --> spb
+    spb -- "GET requests, OAuth tokens" --> spotify
+    spb -- "writes nodes and edges" --> neo4j
+    you -- "writes Cypher queries" --> neo4j
+    ai -- "asks questions via MCP tools" --> mcp
+    mcp -- "read-only Cypher" --> neo4j
+    spb -- "creates/updates playlists (opt-in)" --> spotify
+```
+
+Three things live on your machine:
+
+1. **The Docker Compose stack** — a crawler pipeline plus a small web service
+   for Spotify login. It reads from Spotify and writes into Neo4j. It can also
+   write *back* to Spotify, but only to playlists it created itself.
+2. **Neo4j Desktop** — the database that holds the graph. It runs on the host
+   (not in Docker) so you keep its browser UI and your data survives anything
+   Docker does.
+3. **The MCP server** — a small read-only doorway that lets an AI assistant
+   query the graph in natural language. It runs on demand, not as part of the
+   stack.
+
+Everything is local. There is no cloud deployment and no CI today (that is a
+deliberate choice, not an accident — see [delivery.md](delivery.md)).
+
+---
+
+## Level 2: The containers
+
+One `docker compose up` starts everything below. All the Python services share
+**one Docker image** (`spotify-power-browser`), built once from the repo's
+[Dockerfile](../Dockerfile) — each service just runs a different command
+inside it.
+
+```mermaid
+flowchart TB
+    browser(["🧑‍🎤 Browser<br/>http://127.0.0.1:8000/login"])
+    spotify["🎵 Spotify Web API"]
+
+    subgraph compose ["🐳 Docker Compose: spotify-power-browser"]
+        auth["🐍 spotify_authentication<br/>Falcon web app, port 8000<br/>OAuth login + callback"]
+        factory["🐍 requests_factory_start_crawls<br/>seeds the crawl, then exits"]
+        engine["🐍 api_call_engine<br/>makes every Spotify GET<br/>retries, backoff, token refresh"]
+        rabbit["🐰 RabbitMQ 4<br/>message broker<br/>UI on port 15672"]
+        redis[("🧠 Redis 8<br/>crawled-URL memory +<br/>OAuth state nonces")]
+        disk["🐍 responses_write_to_disk<br/>archives raw JSON"]
+        graphw["🐍 responses_write_to_neo4j<br/>inserts nodes + edges"]
+        follow["🐍 responses_follow_links<br/>queues neighbor URLs"]
+        mock["🎭 spotify_mock<br/>(profile: test/mock)"]
+        tests["🧪 tests<br/>(profile: test)"]
+    end
+
+    subgraph host ["💻 Host"]
+        neo4j[("🕸️ Neo4j Desktop<br/>bolt://host.docker.internal:7687")]
+        secrets["🔑 ./secrets<br/>tokens, credentials"]
+        data["📄 ./data<br/>responses JSON archive"]
+    end
+
+    browser --> auth
+    auth -- "single-use login nonces" --> redis
+    auth -- "writes token files" --> secrets
+    factory -- "publishes seed URLs" --> rabbit
+    factory -- "reads discography seeds" --> neo4j
+    rabbit -- "one request at a time" --> engine
+    engine -- "GET + bearer token" --> spotify
+    engine -- "publishes responses ×3" --> rabbit
+    engine -- "reads tokens" --> secrets
+    rabbit --> disk & graphw & follow
+    follow -- "new URLs back onto the queue" --> rabbit
+    factory & follow -- "have we fetched this URL?" --> redis
+    disk --> data
+    graphw --> neo4j
+    mock -.-> tests
+```
+
+### What each service does
+
+| Service | One-line job | Waits for |
+|---|---|---|
+| `rabbitmq` | The mailbox between every stage. Management UI at http://localhost:15672 (guest/guest). | — |
+| `redis` | Remembers every URL already crawled (survives restarts) and holds one-time login nonces. | — |
+| `spotify_authentication` | Serves the login page; turns your Spotify consent into token files under `secrets/`. | redis |
+| `api_call_engine` | The only service that talks HTTP to Spotify. Consumes request URLs, GETs them, fans results out. | rabbitmq, redis, **auth healthy** |
+| `responses_write_to_disk` | Saves every raw JSON response to `data/responses/` as an audit trail. | rabbitmq |
+| `responses_write_to_neo4j` | Translates responses into graph inserts (`MERGE`, so re-crawls are safe). | rabbitmq |
+| `responses_follow_links` | Finds album/artist references inside responses and queues them for fetching — this is what makes it a *crawler*. | rabbitmq, redis |
+| `requests_factory_start_crawls` | Publishes the first URLs (your Liked Songs page, discography seeds) and exits. | everything above |
+| `spotify_mock` | A fake Spotify for tests and offline runs. Off unless you ask for the `test`/`mock` profile. | — |
+| `tests` | The pytest runner (`docker compose run --rm tests`). Off unless you run it. | rabbitmq, redis, mock |
+
+### Why isn't Neo4j a container?
+
+Neo4j Desktop already runs on the host with its own browser UI and persistent
+storage, and a containerized Neo4j would fight it for port 7687. The workers
+reach it through Docker's `host.docker.internal` gateway. A commented-out
+`neo4j` service in [compose.yaml](../compose.yaml) shows how to go
+fully-in-Docker if you prefer.
+
+### The one clever trick at startup
+
+`spotify_authentication` has a healthcheck that only passes **once a token
+file exists**. The pipeline services declare they depend on it being healthy.
+The effect: `docker compose up` starts the infrastructure, then *pauses* until
+you visit http://127.0.0.1:8000/login and click Agree on Spotify's consent
+page. The moment your token lands on disk, the health flips green and the
+crawl starts on its own. One command, one human click, no scripts in between.
+The full auth story is in [auth.md](auth.md).
+
+---
+
+## Level 3: Inside the pipeline
+
+Everything between "a URL we want" and "data in the graph" flows through two
+RabbitMQ exchanges. A message is a small JSON envelope:
+
+```json
+{
+  "request_url": "https://api.spotify.com/v1/me/tracks?offset=0&limit=20",
+  "depth_of_search": 1,
+  "user_id": "michaelwheeler"
+}
+```
+
+```mermaid
+flowchart LR
+    seeds["🌱 requests_factory<br/>seed URLs"]
+
+    subgraph rabbit ["🐰 RabbitMQ"]
+        reqx{{"spotify_api_requests<br/>queue: make_api_call"}}
+        respx{{"spotify_api_responses<br/>queues: write_to_disk,<br/>write_to_neo4j, follow_links"}}
+    end
+
+    dedup[("🧠 Redis<br/>spb:crawled_urls")]
+    engine["⚙️ api_call_engine<br/>GET · 429 backoff ·<br/>500 retry · 401 refresh"]
+    spotify["🎵 Spotify"]
+
+    dispatcher["🚦 dispatcher<br/>(response_handlers/main.py)<br/>URL pattern → handler class"]
+    disk["📄 write_to_disk"]
+    graphw["🕸️ write_to_neo4j"]
+    follow["🔁 follow_links<br/>depth − 1"]
+
+    seeds -- "url_is_new?" --> dedup
+    seeds --> reqx
+    reqx --> engine
+    engine <--> spotify
+    engine -- "response + envelope" --> respx
+    respx --> dispatcher
+    dispatcher --> disk & graphw & follow
+    follow -- "album/artist URLs at depth − 1" --> dedup
+    follow --> reqx
+```
+
+Step by step:
+
+1. **Seeding.** `requests_factory` publishes the first page of your Liked
+   Songs (and, if `CRAWL_ARTIST_DISCOGRAPHIES=true`, one discography URL per
+   artist you clearly love). Every URL passes through one choke point,
+   `request_url()`, which asks Redis "have we fetched this before?" and skips
+   it if so.
+2. **Fetching.** `api_call_engine` consumes one URL at a time and GETs it with
+   your bearer token. It absorbs the three ways Spotify says no: **429** (rate
+   limited — sleep for `Retry-After`, capped at 10 minutes), **500** (retry up
+   to 5 times), **401** (token expired — refresh it and retry). If it gives up
+   on a URL it *un-marks* it in Redis so a future run can try again. Paginated
+   responses (`"next"` links) are re-queued at the same depth.
+3. **Fan-out.** Each successful response is published three times, once per
+   routing key, so three independent workers process it in parallel.
+4. **Dispatch.** Each worker maps the response's URL to a handler class — e.g.
+   `/v1/me/tracks` → `LikedSongsPlaylistResponseHandler`, `/v1/albums?ids=` →
+   `GetSeveralAlbumsResponseHandler`. One handler class knows everything about
+   one Spotify endpoint: where to save it on disk, which Cypher inserts it,
+   which links inside it are worth following.
+5. **The loop.** `follow_links` publishes the albums and artists mentioned in
+   a response back onto the request queue at **depth − 1**. Depth 0 means
+   "save this but follow nothing." That number is the crawler's only brake —
+   and with Redis dedup it is what keeps a 12,000-track library from becoming
+   a million requests.
+
+### Frequently asked questions
+
+**Why a message queue at all?** Three reasons. It decouples slow Spotify
+fetching (one careful, rate-limited worker) from fast local writing (parallel
+workers). It survives crashes — queues are durable, so a restart picks up
+where it left off. And it gives you free monitoring: the RabbitMQ UI shows
+exactly how much work is left (see [observability.md](observability.md)).
+
+**Why both Redis and RabbitMQ?** They do different jobs. RabbitMQ is the
+mailbox: work that *should happen next*. Redis is the memory: work that
+*already happened* (the crawled-URL set persists across runs on a named
+volume, so tomorrow's crawl skips everything today's crawl fetched).
+
+**What happens if a worker dies mid-crawl?** Queues are durable and messages
+are persistent, so nothing queued is lost. The engine and workers reconnect
+in a loop rather than exiting. The one loss window — a URL marked "crawled"
+whose fetch then failed forever — is closed by the dedup rollback in step 2.
+
+**How does a crawl end?** It just drains. When the queues are empty and
+message rates hit zero, the crawl is done. There is no completion
+notification — see [observability.md](observability.md) for how to watch it.
+
+**What's `write_to_sqlite`?** A stub from the project's early days; the flag
+is off and every handler raises `NotImplementedError`. It's listed as a
+removal candidate in [ROADMAP.md](../ROADMAP.md).
+
+---
+
+## Where the code lives
+
+| Path | What's inside | README |
+|---|---|---|
+| `application/` | Everything the pipeline runs | [README](../application/README.md) |
+| `application/spotify_authentication/` | OAuth web service, token storage, refresh | [README](../application/spotify_authentication/README.md) |
+| `application/response_handlers/` | One handler class per Spotify endpoint + dispatcher | [README](../application/response_handlers/README.md) |
+| `application/graph_database/` | Neo4j connection, every Cypher query, migrations | [README](../application/graph_database/README.md) |
+| `application/message_queue/` | RabbitMQ connect/declare/publish helpers | [README](../application/message_queue/README.md) |
+| `application/cache/` | Redis client: URL dedup + OAuth nonces | [README](../application/cache/README.md) |
+| `application/discovery/` | Artist popularity backfill for discovery ranking | [README](../application/discovery/README.md) |
+| `application/mastering/` | "Same song, five releases" dedup into canonical Songs | [README](../application/mastering/README.md) |
+| `application/annotations/` | Timestamped notes/cues/sections on tracks | [README](../application/annotations/README.md) |
+| `application/playlists/` | Graph-driven playlists written back to Spotify | [README](../application/playlists/README.md) |
+| `mcp_server/` | Read-only MCP server for AI graph exploration | [README](../mcp_server/README.md) |
+| `mock_spotify/` | Controllable fake Spotify (tests + offline runs) | [README](../mock_spotify/README.md) |
+| `tests/` | The pytest suite | [README](../tests/README.md) |
+| `docs/plans/` | Feature plans (implemented and pending) | [README](plans/README.md) |

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,175 @@
+# Identity and access: how Spotify auth works here
+
+Everything in this project that talks to Spotify does it with an OAuth 2.0
+bearer token. This document explains where those tokens come from, where they
+live, how they stay fresh, and exactly where the auth code touches the rest of
+the system — because it is deliberately self-contained and could be lifted out
+as its own small library.
+
+The code lives in
+[application/spotify_authentication/](../application/spotify_authentication/)
+— three files, three jobs:
+
+| File | Job |
+|---|---|
+| `api_authorization_web_service.py` | The login web app (Falcon, port 8000): `/login`, `/login/start`, `/callback` |
+| `token_store.py` | Reads/writes token files, handles multi-user namespacing and the "primary user" rules |
+| `refresh_token.py` | Trades a refresh token for a fresh access token when the old one expires |
+
+---
+
+## The login flow, step by step
+
+```mermaid
+sequenceDiagram
+    actor U as 🧑‍🎤 You (browser)
+    participant A as 🐍 spotify_authentication (:8000)
+    participant R as 🧠 Redis
+    participant S as 🎵 Spotify (accounts + api)
+    participant F as 🔑 secrets/ (files)
+    participant P as 🐳 Pipeline services
+
+    U->>A: GET /login  (the "add a user" page)
+    U->>A: GET /login/start
+    A->>R: store single-use state nonce (TTL 10 min)
+    A-->>U: 303 redirect to Spotify authorize (never cached)
+    U->>S: log in, click Agree (scopes granted)
+    S-->>U: redirect to /callback?code=…&state=…
+    U->>A: GET /callback
+    A->>R: consume nonce (GETDEL — valid exactly once)
+    A->>S: exchange code for tokens (client id+secret)
+    A->>S: GET /v1/me  — whose token is this?
+    A->>F: write secrets/users/<their_id>/…  (+ legacy mirror if primary)
+    P->>F: healthcheck sees the token file
+    Note over P: gate opens — the crawl starts
+```
+
+Details worth knowing:
+
+- **The state nonce is CSRF protection.** `/login/start` mints a random
+  value, parks it in Redis with a 10-minute TTL, and sends it to Spotify.
+  `/callback` will only proceed if it can atomically consume that exact value
+  (`GETDEL` — so it works exactly once). The redirect is a `303` with
+  `Cache-Control: no-store` because a cacheable redirect would replay a
+  used-up nonce and mysteriously break every later login from that browser.
+- **Identity is derived, not assumed.** The callback never trusts who it
+  *thinks* logged in; it asks `GET /v1/me` whose token it just received, and
+  files the tokens under that user id.
+- **Scopes are bundled.** One consent grants everything any current feature
+  needs, so nobody has to re-authorize per feature:
+
+  | Scope | Used by |
+  |---|---|
+  | `user-library-read` | The Liked Songs crawl |
+  | `user-read-playback-state` | Live annotation capture (`listen.py`) |
+  | `playlist-modify-private` | Playlist write-back |
+  | `playlist-read-private`, `user-follow-read`, `user-read-recently-played`, `user-top-read` | Plan 02 (listening history) — requested now so it's ready |
+
+---
+
+## Where tokens live
+
+```
+secrets/
+├── spotify_client_id.secret          ← your app's ID (you create this)
+├── spotify_client_secret.secret      ← your app's secret (you create this)
+├── spotify_api_token.secret          ← LEGACY MIRROR: the primary user's access token
+├── spotify_refresh_token.secret      ← LEGACY MIRROR: the primary user's refresh token
+└── users/
+    ├── .primary_user                 ← contains the primary user's id
+    ├── michael/
+    │   ├── spotify_api_token.secret
+    │   └── spotify_refresh_token.secret
+    └── sarah/
+        └── …
+```
+
+**The primary user** is simply the first account that ever logged in, and the
+role is sticky — later logins never steal it. Their tokens are *mirrored* to
+the two legacy top-level files on every save and refresh. Two things depend on
+that mirror:
+
+1. The compose healthcheck (`test -s secrets/spotify_api_token.secret`) that
+   gates the whole pipeline — so one `docker compose up` still works with any
+   number of users.
+2. Older single-user code paths that read the legacy files directly.
+
+Practical rule: **don't delete the legacy files or `.primary_user`** while the
+system is in use. (The full "remove a user / change primary" procedure is in
+the [multiplayer runbook](multiplayer-runbook.md).)
+
+User ids come back from a remote API but are used as directory names, so
+`token_store.validate_user_id()` rejects anything that could traverse paths.
+
+---
+
+## Staying logged in: token refresh
+
+Spotify access tokens die after about an hour; crawls can run longer. When the
+engine gets a **401** it calls `refresh_spotify_auth(user_id)`, which POSTs
+the refresh token to Spotify **with HTTP Basic client authentication** —
+that last part matters, because omitting it was the bug that used to kill
+every crawl at the one-hour mark (fixed in PR #16).
+
+Two subtleties the code handles for you:
+
+- Spotify usually *omits* a new refresh token in the response; the old one
+  stays valid and is kept (RFC 6749 §6 behavior).
+- Refreshes are mirrored **both ways** for the primary user: a legacy-path
+  refresh updates the namespaced files and vice versa. If they drifted, the
+  primary's next 401 would replay a stale refresh token and Spotify would
+  reject it (`invalid_grant`), wedging their crawl until a manual re-login.
+
+If a refresh fails outright (revoked grant, deleted token file), the engine
+rolls back the "already crawled" mark on the URL it was fetching, so nothing
+is silently lost — the URL is retried after you re-authorize.
+
+---
+
+## Where auth touches the rest of the codebase
+
+The surface is intentionally tiny. Only three production modules import from
+`spotify_authentication`:
+
+| Caller | What it uses | Why |
+|---|---|---|
+| `application/api_call_engine.py` | `read_api_token`, `refresh_spotify_auth`, `has_user` | Attach a bearer to every GET; refresh on 401 |
+| `application/playlists/sync.py` | `refresh_spotify_auth` | Same refresh-and-retry when writing playlists |
+| `application/response_handlers/me/my_liked_songs.py` | `validate_user_id` | Safe per-user directory names for the disk archive |
+
+(Plus the migration runner, which reads the primary user id as a default, and
+the tests.)
+
+**Could this be extracted as a standalone library?** Yes, with one caveat.
+The web service + token store + refresh logic have no dependency on the
+pipeline — they know nothing about RabbitMQ, Neo4j, or crawling. The one
+external dependency is Redis, used only for the login nonces; an extracted
+version would either bring a Redis client along or accept any
+store-and-consume-once backend. The interface the rest of an application needs
+is four functions: `read_api_token(user_id)`, `save_tokens(…)`,
+`refresh_spotify_auth(user_id)`, `list_user_ids()`.
+
+---
+
+## FAQ
+
+**Why must the redirect URI be `http://127.0.0.1:8000/callback` and not
+`localhost`?** Spotify rejects `localhost` as insecure but accepts the
+loopback IP. It must match the Spotify app dashboard exactly.
+
+**Why does the pipeline wait for me at startup?** The auth container's
+healthcheck only passes once a token file exists and is non-empty. Every
+pipeline service depends on that health. The healthcheck's `start_period` is
+one hour, so compose patiently shows "waiting" rather than failing while you
+find your password.
+
+**How does a second person log in?** Same page — `/login`, then "Add a
+user". Their tokens land in their own directory and the primary is untouched.
+One prerequisite: while your Spotify app is in development mode you must
+allowlist their email in the Spotify developer dashboard first. Full walkthrough:
+[multiplayer runbook](multiplayer-runbook.md).
+
+**What would production hardening look like?** Tokens are plaintext files on
+disk, which is fine for a personal project on your own machine and the reason
+this section exists in the AWS plans: the migration sketch moves them to AWS
+Secrets Manager (see [delivery.md](delivery.md)).

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,286 @@
+# The data model, told as a story
+
+This document explains what's actually *in* the graph — not as a schema dump,
+but by following real data through the system. If you read only one doc before
+opening the Neo4j browser, read this one.
+
+The Mermaid diagrams here have Lucid twins — see
+[docs/diagrams/README.md](diagrams/README.md).
+
+---
+
+## The cast of characters
+
+Every node in the graph is one of these:
+
+| Node | What it represents | Where it comes from |
+|---|---|---|
+| `Track` | One playable recording on Spotify | The crawl |
+| `Album` | One release (album, single, compilation) | The crawl |
+| `Artist` | One artist page on Spotify | The crawl |
+| `Genre` | A Spotify genre tag like "uk garage" | Artist metadata during the crawl |
+| `User` | A person whose library is in this graph | Migration 0001 + each `/login` |
+| `Song` | One *canonical* song, no matter how many releases it's on | The mastering batch job |
+| `Note`, `Cue`, `Section` | Your timestamped listening annotations | The annotation CLIs |
+| `ManagedPlaylist` | A Spotify playlist this system created and maintains | The playlist sync CLI |
+
+And the relationships between them:
+
+```mermaid
+flowchart TB
+    user(["👤 User"])
+    track["🎧 Track"]
+    album["💿 Album"]
+    artist["🎤 Artist"]
+    genre["🏷️ Genre"]
+    song["🎼 Song"]
+    song2["🎼 Song (parent)"]
+    note["📝 Note"]
+    cue["📍 Cue"]
+    section["📐 Section"]
+    section2["📐 Section (next)"]
+    playlist["📋 ManagedPlaylist"]
+
+    user -- "LIKED {added_at}" --> track
+    user -- "HAS_MANAGED" --> playlist
+    album -- "CONTAINS" --> track
+    artist -- "CREATED" --> track
+    artist -- "CREATED" --> album
+    artist -- "SPOTIFY_CLASSIFIED_AS" --> genre
+    track -- "VERSION_OF {kind, method, confidence}" --> song
+    song -- "REMIX_OF {confidence}" --> song2
+    track -- "HAS_NOTE" --> note
+    track -- "HAS_CUE" --> cue
+    track -- "HAS_SECTION" --> section
+    section -- "NEXT" --> section2
+```
+
+Two layers matter enormously and are worth naming:
+
+- **The catalog layer** (`Track`, `Album`, `Artist`, `Genre`, `Song`) is
+  *shared*. These nodes are `MERGE`d on stable Spotify IDs, so if you and a
+  friend both like "Blinding Lights", there is exactly **one** Track node and
+  you both point at it.
+- **The ownership layer** (`User` and its `LIKED` / `HAS_MANAGED` edges) is
+  *per-person*. Who likes what lives on relationships, never on the catalog
+  nodes themselves. This is what makes shared graphs work.
+
+---
+
+## Story 1: One liked song's journey into the graph
+
+You tapped ♥ on **"Blinding Lights"** in October 2023. Here is what happens
+when the crawler meets that fact.
+
+```mermaid
+flowchart LR
+    s1["🎵 Spotify responds:<br/>GET /v1/me/tracks<br/>one page, 20 liked songs"]
+    s2["📨 Envelope rides RabbitMQ:<br/>{request_url, depth: 1,<br/>user_id: michael}"]
+    s3["🚦 Handler:<br/>LikedSongsPlaylist<br/>ResponseHandler"]
+    s4["📄 Disk:<br/>data/responses/liked_songs/<br/>michael/0.json"]
+    s5["🕸️ Graph: MERGE<br/>Track · Album · Artist ·<br/>LIKED · CONTAINS · CREATED"]
+    s6["🔁 Follow:<br/>album + artists queued<br/>at depth 0"]
+
+    s1 --> s2 --> s3
+    s3 --> s4
+    s3 --> s5
+    s3 --> s6
+```
+
+**1. Spotify answers.** One page of your Liked Songs arrives as JSON. The
+interesting part of one item:
+
+```json
+{
+  "added_at": "2023-10-15T14:22:00Z",
+  "track": {
+    "id": "0VjIjW4GlUZAMYd2vXMwbk",
+    "name": "Blinding Lights",
+    "duration_ms": 200040,
+    "external_ids": { "isrc": "USUG11904206" },
+    "album":   { "id": "4yP0hdKOZPNshxUOjY0cZj", "name": "After Hours" },
+    "artists": [ { "id": "1Xyo4u8uIGDwSrnxfEnP4x", "name": "The Weeknd" } ]
+  }
+}
+```
+
+**2. The graph write.** The handler runs
+[insert_batch_of_liked_songs.cypher](../application/graph_database/queries/insert_batch_of_liked_songs.cypher),
+which `MERGE`s (create-if-missing, reuse-if-present):
+
+```
+(:User {id: "michael"})
+      -[:LIKED {added_at: "2023-10-15T14:22:00Z"}]-> (:Track {id: "0VjIjW…", name: "Blinding Lights", isrc: "USUG…"})
+(:Album {id: "4yP0…", name: "After Hours"}) -[:CONTAINS]-> that Track
+(:Artist {id: "1Xyo…", name: "The Weeknd"}) -[:CREATED]->  that Track
+(:Artist)                                    -[:CREATED]->  that Album
+```
+
+Notice *when you liked it* lives on the `LIKED` edge — a fact about you — while
+*how long the song is* lives on the Track — a fact about the world.
+
+**3. The ripple.** `follow_links` queues the album and artist URLs at
+depth − 1. Their full objects arrive later and enrich the same nodes (genres
+land on the Artist, release date on the Album). Because everything is MERGE,
+re-crawling next month updates in place; nothing duplicates.
+
+Multiply this by ~12,500 liked songs and you get the real numbers from the
+first full crawl: **12,547 Tracks, 9,832 Albums, 7,587 Artists, 634 Genres in
+about 18 minutes.**
+
+---
+
+## Story 2: Five releases, one song (mastering)
+
+Your library almost certainly contains the same recording several times:
+"Levitating", "Levitating – Radio Edit", "Levitating (Deluxe)". For counting
+and DJ purposes those are one song. The **mastering** job
+(`python -m application.mastering.run`) rolls them up without destroying
+anything:
+
+```
+(:Track "Levitating")               -[:VERSION_OF {kind: "canonical",  method: "isrc",      confidence: 1.0}]-> (:Song "levitating")
+(:Track "Levitating – Radio Edit")  -[:VERSION_OF {kind: "radio_edit", method: "heuristic", confidence: 0.85}]-> same Song
+(:Song "levitating (the blessed madonna remix)") -[:REMIX_OF {confidence: 0.9}]-> (:Song "levitating")
+```
+
+How it decides two Tracks are the same Song, strongest evidence first:
+**1)** same ISRC (the recording industry's serial number), **2)** Spotify's
+own `linked_from` re-linking, **3)** a heuristic — same normalized title +
+same primary artist + duration within 3 seconds, **4)** your manual overrides
+in `secrets/mastering_overrides.yaml`, which always win. Remixes are *never*
+merged into their parent — a remix is a different song — they get their own
+Song plus a `REMIX_OF` edge.
+
+Every run writes a human review report to `data/mastering_review.md`, most
+ambiguous clusters first, so you can catch bad merges and fix them with an
+override. Details: [application/mastering/README.md](../application/mastering/README.md).
+
+---
+
+## Story 3: A friend joins the graph (multiplayer)
+
+Sarah logs in through `/login` and you crawl her library
+(`CRAWL_USER=sarah docker compose up requests_factory_start_crawls`). What
+changes in the graph?
+
+- A `(:User {id: "sarah"})` node appears.
+- Her ~3,000 liked songs become `(:User {id:"sarah"})-[:LIKED]->(:Track)`
+  edges. Where you overlap, her edges attach to **your existing Track nodes** —
+  no duplication, the overlap simply *is* the set of Tracks with two LIKED
+  edges.
+- The shared catalog gets a little bigger (her tracks you'd never heard of).
+
+```mermaid
+flowchart LR
+    you(["👤 You"])
+    sarah(["👤 Sarah"])
+    shared["🎧 Blinding Lights<br/>(one shared Track node)"]
+    yours["🎧 A track only<br/>you like"]
+    hers["🎧 A track only<br/>she likes"]
+
+    you -- "LIKED 2023-10-15" --> shared
+    sarah -- "LIKED 2024-02-01" --> shared
+    you -- "LIKED" --> yours
+    sarah -- "LIKED" --> hers
+```
+
+This is why migration
+[0001_multiplayer_ownership](../application/graph_database/migrations/0001_multiplayer_ownership.cypher)
+exists: the original single-user graph marked likes as a `liked_songs: true`
+property *on the Track itself*, which can't distinguish two people. The
+migration lifted every such flag onto a `LIKED` edge owned by you. (Migration
+0002, still a guarded stub, will eventually delete the legacy properties once
+the rollback window closes.)
+
+Once two users are in, the **overlap query pack**
+([queries/overlap/](../application/graph_database/queries/overlap/)) answers
+the fun questions — see [exploring-the-graph.md](exploring-the-graph.md) for a
+guided tour.
+
+---
+
+## Story 4: A listening session leaves a trail (annotations)
+
+You put on an album and run the live-capture CLI
+(`python3 -m application.annotations.listen`). Every time you tap a hotkey it
+polls where playback is and writes a node:
+
+- tap `c` at the drop → `(:Track)-[:HAS_CUE]->(:Cue {at_ms: 130000, label: "drop"})`
+- tap `n` and type a thought → `(:Track)-[:HAS_NOTE]->(:Note {text: "…", at_ms: 41000})`
+- tap `s` at each boundary → `(:Section {kind: "buildup", start_ms, end_ms})`
+  nodes, chained to each other with `NEXT` edges in time order
+
+The `NEXT` chain is kept sorted by start time even if you mark boundaries out
+of order, and the insert queries only ever `MATCH` the Track — you can't
+annotate a song the crawl hasn't seen. Details:
+[application/annotations/README.md](../application/annotations/README.md).
+
+---
+
+## Story 5: The graph writes back (managed playlists)
+
+Insights shouldn't be trapped in the database. The playlist sync CLI turns a
+graph query into a real Spotify playlist and records what it did:
+
+```
+(:User)-[:HAS_MANAGED]->(:ManagedPlaylist {
+    spotify_id: "3cEYpjA9oz9GiPac4AsH4n",
+    generator: "adjacent_discoveries",
+    params_hash: "a94a8fe5…",        // same inputs → same playlist next run
+    last_synced: "2026-07-06T21:04:00Z",
+    target_snapshots: [ …last 3 track lists, for rollback… ]
+})
+```
+
+The safety rule is absolute: before any write to Spotify, the sync code checks
+the playlist ID is recorded as managed here. Hand-made playlists are never
+touched. Dry-run is the default. Details:
+[application/playlists/README.md](../application/playlists/README.md).
+
+---
+
+## Reference: properties you'll actually query
+
+- **Track** — `id`, `name`, `duration_ms`, `explicit`, `isrc` (for
+  mastering), `artist_ids` (credit order; element 0 is the primary artist).
+- **Album** — `id`, `name`, `release_date`, `album_type`, `total_tracks`.
+- **Artist** — `id`, `name`, `popularity` (0–100, filled by the
+  [backfill](../application/discovery/README.md); `null` means "not enriched
+  yet"), `followers`.
+- **Genre** — just `name`. Genres hang off Artists, not Tracks, because that's
+  how Spotify models them.
+- **User** — `id` (the Spotify username), `display_name`, `added_at`.
+- **LIKED edge** — `added_at`: when that user liked that track. The backbone
+  of every taste-over-time question.
+- **VERSION_OF edge** — `kind` (canonical / remaster / radio_edit / live /
+  clean / explicit / demo / remix), `method` (isrc / linked_from / heuristic /
+  manual), `confidence` (0–1).
+
+Uniqueness constraints exist on `Track.id`, `Album.id`, `Artist.id`,
+`Song.id`, `User.id`, `Note.id`, `Cue.id`, `Section.id`, and
+`ManagedPlaylist.spotify_id` — applied automatically at startup by
+[initialize_database_environment.py](../application/graph_database/initialize_database_environment.py).
+
+---
+
+## FAQ
+
+**Why is `liked` a relationship and not a property?** Because "liked" is a
+fact about a *(person, track)* pair. As a property, one graph can hold one
+person's taste. As a relationship, it holds any number of people — and overlap
+questions become simple pattern matches.
+
+**What happens on a re-crawl?** Everything is `MERGE` on stable IDs:
+existing nodes are updated (`ON MATCH SET` refreshes things like popularity),
+new nodes are created, and nothing duplicates.
+
+**Do Tracks belong to a User?** No. Catalog nodes are ownerless and shared.
+Deleting a user (`DETACH DELETE` their User node + removing their token
+directory) removes their edges and leaves the catalog intact — that's the
+"right to be forgotten" one-liner in the
+[multiplayer runbook](multiplayer-runbook.md).
+
+**Where do Play / listening-history nodes fit?** They don't exist yet. Plan 02
+(listening completeness) will add `(:User)-[:DID]->(:Play)-[:OF]->(:Track)`
+when Spotify's extended streaming history export is ingested.

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -1,0 +1,145 @@
+# Delivery: how this software gets built and run
+
+Short version: **everything is local Docker Compose.** There is no CI, no
+GitHub Actions, no cloud deployment — the repo on GitHub is source hosting
+only. This page covers the paths that do exist, and the AWS path that's
+planned but not built.
+
+```mermaid
+flowchart TB
+    code["📦 Source checkout"]
+    build["🏗️ docker compose build<br/>ONE image: spotify-power-browser<br/>(python:3.13-slim + Poetry deps<br/>+ application/ + mcp_server/)"]
+
+    subgraph paths ["The four ways to run it"]
+        live["▶️ Live crawl<br/>docker compose up"]
+        testrun["🧪 Test suite<br/>docker compose run --rm tests"]
+        mockrun["🎭 Offline mock crawl<br/>compose -f compose.yaml<br/>-f docker-compose.mock.yml up"]
+        mcprun["🔌 MCP server<br/>scripts/mcp_server.sh<br/>(docker run, on demand)"]
+    end
+
+    worktree["🌿 Worktree isolation<br/>SessionStart hook writes .env<br/>(IMAGE_TAG + project name)<br/>+ override (no host ports)"]
+    cloud["☁️ AWS (planned, not built)<br/>mock service first on Fargate,<br/>then the real pipeline"]
+
+    code --> build
+    build --> live & testrun & mockrun & mcprun
+    worktree -. "namespaces parallel stacks" .-> live & testrun
+    paths -. "someday" .-> cloud
+```
+
+---
+
+## One image for everything
+
+The [Dockerfile](../Dockerfile) builds a single image: Python 3.13-slim,
+Poetry-installed dependencies, plus the `application/` and `mcp_server/`
+source. Every compose service uses that same image and just runs a different
+`command:`. So "deploying a change" is:
+
+```bash
+docker compose build          # rebuild the shared image
+docker compose up             # services pick it up
+```
+
+There's no registry; the image only ever lives in your local Docker daemon.
+Dependencies are pinned by `poetry.lock`, so builds are reproducible.
+
+## Path 1: the live crawl
+
+```bash
+docker compose up
+```
+
+Starts RabbitMQ, Redis, the auth service, and the pipeline workers; pauses at
+the OAuth gate until you log in at http://127.0.0.1:8000/login; then crawls.
+The startup choreography is described in
+[architecture.md](architecture.md#the-one-clever-trick-at-startup), the knobs
+(RESET_CRAWL, CRAWL_USER, …) in the [root README](../README.md#configuration).
+The `spin-up` skill (`.claude/skills/spin-up/`) walks an AI assistant through
+the whole thing.
+
+## Path 2: the test suite
+
+```bash
+docker compose run --rm tests
+```
+
+The `tests` and `spotify_mock` services are **profile-gated** — they exist in
+compose.yaml but are not part of a normal `up`. This command brings up
+RabbitMQ, Redis, and the mock, then runs pytest. Tests that need the host
+Neo4j skip politely if it isn't running. The secrets directory is mounted
+**read-only** so no test can ever clobber your real tokens. More in
+[testing.md](testing.md).
+
+## Path 3: the offline mock crawl
+
+```bash
+echo -n mock-access-token > secrets/spotify_api_token.secret
+echo -n mock-refresh-token > secrets/spotify_refresh_token.secret
+RESET_CRAWL=true docker compose -f compose.yaml -f docker-compose.mock.yml up
+```
+
+[docker-compose.mock.yml](../docker-compose.mock.yml) is an overlay that
+points every pipeline service's Spotify URLs at the bundled fake
+(`http://spotify_mock`). The whole crawl then runs with **no internet and no
+real account** against a deterministic synthetic catalog — useful for demos,
+debugging the pipeline itself, and testing failure handling (the mock can be
+told to throw 429s/401s/500s on command). See
+[mock_spotify/README.md](../mock_spotify/README.md).
+
+## Path 4: the MCP server
+
+```bash
+bash scripts/mcp_server.sh     # (Claude launches this for you via .mcp.json)
+```
+
+Not a compose service at all: a `docker run --rm -i` of the same image,
+started on demand by an AI client and speaking MCP over stdio. See
+[mcp_server/README.md](../mcp_server/README.md).
+
+---
+
+## Parallel checkouts: the worktree trick
+
+If you (or several Claude Code sessions) work in git worktrees, all those
+checkouts share one Docker daemon — and would normally fight over the image
+tag `latest`, the compose project name, and host ports 5672/15672/8000.
+
+A `SessionStart` hook ([scripts/worktree_compose_env.sh](../scripts/worktree_compose_env.sh))
+solves this. In any checkout under `.claude/worktrees/` it writes two
+gitignored files:
+
+- **`.env`** — `IMAGE_TAG=<branch-slug>` and
+  `COMPOSE_PROJECT_NAME=spotify-power-browser-<branch-slug>`, so each worktree
+  builds its own image tag and gets its own containers/networks/volumes.
+- **`compose.override.yaml`** — `ports: !reset []`, so worktree stacks publish
+  **no host ports** (their services talk over the project network).
+
+The primary checkout is deliberately left alone: it keeps `latest`, the
+published ports, and the warm `redis_data` volume. **Live crawls run only from
+the primary checkout, one at a time** — they share the real Neo4j graph and
+the real dedup cache, which don't multiplex.
+
+## What about CI?
+
+There is none — no `.github/` directory exists. Tests run when you run them.
+This is the honest current state, and adding a GitHub Actions workflow
+(build the image, run the unit-and-mock subset of the suite) is the obvious
+first step whenever the project wants it; nothing in the test design blocks
+it, since the suite already skips service-dependent tests gracefully.
+
+## What about the cloud?
+
+Planned, not built. The strategy (written up in
+[mock-spotify-service.md](mock-spotify-service.md)) is deliberately
+mock-first:
+
+1. ✅ **Done:** configurable Spotify base URLs; the mock service with failure
+   injection (this is what the resilience tests use today).
+2. **Next:** deploy the *mock* to AWS Fargate as a throwaway first workload —
+   learn the ECS/ALB/IaC ropes on something with no secrets and no state.
+3. **Then:** migrate the real pipeline: workers → Fargate, RabbitMQ →
+   Amazon MQ or SQS, Redis → ElastiCache, Neo4j → Aura, token files →
+   Secrets Manager.
+
+Until then, treating "my laptop" as the production environment is a feature:
+one command, no bill, and your listening data never leaves your machine.

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,0 +1,53 @@
+# System diagrams: Lucid vs Mermaid, side by side
+
+Every diagram in this project exists twice, with the same content and
+structure, so the two tools can be compared and the better one kept:
+
+- **Lucid** — one document, ten pages, with real product logos:
+  **[Spotify Power Browser — System Diagrams (C4)](https://lucid.app/lucidchart/092eb27a-7dda-48c1-9302-dcb6ab8ddde5/edit)**
+- **Mermaid** — embedded in the docs, rendered by GitHub, using emoji as
+  icons (GitHub's Mermaid can't load image icons).
+
+| # | Diagram | Lucid page | Mermaid twin lives in |
+|---|---|---|---|
+| 1 | System context (C4 level 1) | 1 | [architecture.md](../architecture.md#level-1-the-system-in-its-world) |
+| 2 | Containers — the Compose stack (C4 level 2) | 2 | [architecture.md](../architecture.md#level-2-the-containers) |
+| 3 | Inside the pipeline (C4 level 3) | 3 | [architecture.md](../architecture.md#level-3-inside-the-pipeline) |
+| 4 | The OAuth login flow | 4 | [auth.md](../auth.md#the-login-flow-step-by-step) |
+| 5 | The graph data model | 5 | [data-model.md](../data-model.md#the-cast-of-characters) |
+| 6 | One liked song's journey | 6 | [data-model.md](../data-model.md#story-1-one-liked-songs-journey-into-the-graph) |
+| 7 | Delivery paths | 7 | [delivery.md](../delivery.md) |
+| 8 | Monitoring map | 8 | [observability.md](../observability.md) |
+| 9 | Test coverage map | 9 | [testing.md](../testing.md) |
+| 10 | Exploring the graph through MCP | 10 | [mcp_server/README.md](../../mcp_server/README.md) |
+
+## How to judge the comparison
+
+Things to weigh while flipping between the two:
+
+- **Fidelity:** Lucid pages carry real logos and precise layout; Mermaid gets
+  emoji and auto-layout. For a portfolio page viewed on GitHub, Mermaid wins
+  on zero-friction rendering; for a presentation or wiki, Lucid looks better.
+- **Maintenance:** the Mermaid sources live *inside* the docs they
+  illustrate — edit the doc, the diagram updates in the same PR, and it
+  diffs like code. The Lucid document is regenerated from
+  [gen_lucid.py](gen_lucid.py) (see below) or edited by hand in the app —
+  either way it lives outside version control.
+- **Linkability:** Mermaid diagrams appear inline where you're already
+  reading; Lucid needs a click out (and a Lucid account for editing).
+
+## Regenerating the Lucid document
+
+[gen_lucid.py](gen_lucid.py) builds the entire ten-page document as Lucid
+Standard Import JSON — layout coordinates, colors, logo URLs, every line and
+label:
+
+```bash
+python3 docs/diagrams/gen_lucid.py     # writes spb_lucid.json next to cwd
+```
+
+Then import `spb_lucid.json` via Lucid's MCP tool
+(`lucid_create_diagram_from_specification`, with assisted layout off) or the
+Lucid Standard Import API. Note the logo icons use Google's favicon service
+(`google.com/s2/favicons?domain=…`) because Lucid's importer renders raster
+images reliably but silently drops SVG URLs.

--- a/docs/diagrams/gen_lucid.py
+++ b/docs/diagrams/gen_lucid.py
@@ -1,0 +1,346 @@
+"""Generate the Lucid Standard Import JSON for the Spotify Power Browser doc set.
+
+Ten pages mirroring the Mermaid diagrams embedded in docs/. Hand-placed
+layouts (no assisted layout) because logo images float next to their boxes.
+"""
+import json
+
+ICONS = {
+    "rabbitmq": "https://www.google.com/s2/favicons?domain=rabbitmq.com&sz=64",
+    "redis": "https://www.google.com/s2/favicons?domain=redis.io&sz=64",
+    "neo4j": "https://www.google.com/s2/favicons?domain=neo4j.com&sz=64",
+    "spotify": "https://www.google.com/s2/favicons?domain=spotify.com&sz=64",
+    "docker": "https://www.google.com/s2/favicons?domain=docker.com&sz=64",
+    "python": "https://www.google.com/s2/favicons?domain=python.org&sz=64",
+    "anthropic": "https://www.google.com/s2/favicons?domain=anthropic.com&sz=64",
+    "pytest": "https://www.google.com/s2/favicons?domain=pytest.org&sz=64",
+    "falcon": "https://www.google.com/s2/favicons?domain=falcon.readthedocs.io&sz=64",
+}
+
+# palette: (fill, stroke)
+P = {
+    "py":      ("#EEF5FB", "#3776AB"),
+    "rabbit":  ("#FFE9D6", "#FF6600"),
+    "redis":   ("#FFE3E0", "#FF4438"),
+    "neo":     ("#E3EDF9", "#4581C3"),
+    "spotify": ("#E2F7E9", "#1DB954"),
+    "person":  ("#FDEBF3", "#C2185B"),
+    "data":    ("#FFF7E0", "#D4A017"),
+    "note":    ("#FFFDE7", "#B8A94A"),
+    "ai":      ("#F3EFEA", "#D97757"),
+    "plain":   ("#FFFFFF", "#555555"),
+    "ghost":   ("#FAFAFA", "#999999"),
+}
+
+_id = [0]
+def nid(prefix):
+    _id[0] += 1
+    return f"{prefix}{_id[0]}"
+
+class Page:
+    def __init__(self, pid, title):
+        self.d = {"id": pid, "title": title, "shapes": [], "lines": []}
+
+    def shape(self, typ, x, y, w, h, text=None, pal=None, dashed=False, **extra):
+        s = {"id": nid("s"), "type": typ, "boundingBox": {"x": x, "y": y, "w": w, "h": h}}
+        if text is not None:
+            s["text"] = text
+        if pal:
+            fill, stroke = P[pal]
+            s["style"] = {"fill": {"type": "color", "color": fill},
+                          "stroke": {"color": stroke, "width": 2,
+                                     "style": "dashed" if dashed else "solid"}}
+        s.update(extra)
+        self.d["shapes"].append(s)
+        return s["id"]
+
+    def box(self, x, y, w, h, text, pal="plain", icon=None, typ="rectangle", dashed=False):
+        """A shape with an optional logo image floating above its top edge."""
+        sid = self.shape(typ, x, y, w, h, text, pal, dashed)
+        if icon:
+            self.d["shapes"].append({
+                "id": nid("i"), "type": "image",
+                "boundingBox": {"x": x + w/2 - 16, "y": y - 40, "w": 32, "h": 32},
+                "image": {"type": "image", "url": ICONS[icon]},
+                "stroke": {"color": "#00000000", "width": 1, "style": "solid"},
+            })
+        return sid
+
+    def container(self, x, y, w, h, title, pal="plain", icon=None, dashed=False):
+        fill, stroke = P[pal]
+        c = {"id": nid("c"), "type": "rectangleContainer",
+             "boundingBox": {"x": x, "y": y, "w": w, "h": h},
+             "containerTitle": {"text": title},
+             "style": {"fill": {"type": "color", "color": fill + "55"},
+                       "stroke": {"color": stroke, "width": 2,
+                                  "style": "dashed" if dashed else "solid"}}}
+        self.d["shapes"].insert(0, c)  # containers behind everything
+        if icon:
+            self.d["shapes"].append({
+                "id": nid("i"), "type": "image",
+                "boundingBox": {"x": x + w - 44, "y": y + 10, "w": 32, "h": 32},
+                "image": {"type": "image", "url": ICONS[icon]},
+                "stroke": {"color": "#00000000", "width": 1, "style": "solid"},
+            })
+        return c["id"]
+
+    def note(self, x, y, w, h, text):
+        return self.shape("note", x, y, w, h, text, "note")
+
+    def line(self, a, b, label=None, dashed=False, color="#555555", both=False):
+        l = {"id": nid("l"), "lineType": "elbow",
+             "endpoint1": {"type": "shapeEndpoint",
+                           "style": "arrow" if both else "none", "shapeId": a},
+             "endpoint2": {"type": "shapeEndpoint", "style": "arrow", "shapeId": b},
+             "stroke": {"color": color, "width": 2,
+                        "style": "dashed" if dashed else "solid"}}
+        if label:
+            l["text"] = [{"text": label, "position": 0.5, "side": "middle"}]
+        self.d["lines"].append(l)
+
+pages = []
+
+# ---------------------------------------------------------------- page 1
+p = Page("p1", "1. System context (C4-1)")
+you    = p.box(80, 80, 190, 90, "You\n(the tastemaker)", "person", typ="circle")
+friend = p.box(320, 80, 190, 90, "A friend\n(second user)", "person", typ="circle")
+ai     = p.box(1120, 80, 240, 80, "AI assistant\nClaude Desktop / Claude Code", "ai", icon="anthropic")
+mach   = p.container(60, 300, 940, 460, "Your machine")
+spb    = p.box(120, 380, 320, 130, "Spotify Power Browser\nDocker Compose stack:\ncrawler pipeline + OAuth service", "py", icon="docker")
+neo    = p.box(620, 370, 300, 100, "Neo4j Desktop\nthe taste graph", "neo", icon="neo4j", typ="database")
+mcp    = p.box(620, 560, 300, 100, "MCP server\nread-only graph access", "py", icon="python")
+spot   = p.box(1120, 400, 260, 110, "Spotify Web API\napi.spotify.com\naccounts.spotify.com", "spotify", icon="spotify")
+p.line(you, spb, "logs in once, watches the crawl")
+p.line(friend, spb, "adds their library via /login")
+p.line(spb, spot, "GET crawl + OAuth; guarded playlist writes")
+p.line(spb, neo, "writes nodes and edges")
+p.line(you, neo, "Cypher in the Neo4j browser", dashed=True)
+p.line(ai, mcp, "questions via MCP tools")
+p.line(mcp, neo, "read-only Cypher")
+pages.append(p)
+
+# ---------------------------------------------------------------- page 2
+p = Page("p2", "2. Containers (C4-2): the Compose stack")
+browser = p.box(90, 70, 200, 90, "You\n(browser)", "person", typ="circle")
+spot    = p.box(1180, 70, 250, 90, "Spotify Web API", "spotify", icon="spotify")
+dockerc = p.container(60, 260, 1010, 800, "Docker Compose project: spotify-power-browser", "py", icon="docker")
+auth    = p.box(120, 350, 260, 110, "spotify_authentication\nFalcon web app :8000\nOAuth login + callback", "py", icon="falcon")
+redis   = p.box(470, 350, 230, 100, "redis\ncrawled-URL memory\n+ login nonces", "redis", icon="redis", typ="database")
+factory = p.box(120, 540, 260, 110, "requests_factory_start_crawls\nseeds the crawl, then exits", "py", icon="python")
+rabbit  = p.box(470, 540, 230, 110, "rabbitmq\nmessage broker\nUI :15672", "rabbit", icon="rabbitmq")
+engine  = p.box(790, 540, 250, 110, "api_call_engine\nevery Spotify GET:\nretry, backoff, refresh", "py", icon="python")
+disk    = p.box(120, 750, 260, 100, "responses_write_to_disk\narchives raw JSON", "py", icon="python")
+graphw  = p.box(430, 750, 260, 100, "responses_write_to_neo4j\ninserts nodes + edges", "py", icon="python")
+follow  = p.box(750, 750, 260, 100, "responses_follow_links\nqueues neighbor URLs", "py", icon="python")
+mock    = p.box(120, 930, 260, 90, "spotify_mock\n(profiles: test, mock)", "ghost", dashed=True)
+tests   = p.box(430, 930, 260, 90, "tests\n(profile: test)", "ghost", dashed=True, icon="pytest")
+hostc   = p.container(1130, 260, 360, 620, "Host machine")
+neo     = p.box(1170, 340, 280, 110, "Neo4j Desktop\nbolt://host.docker.internal:7687", "neo", icon="neo4j", typ="database")
+secrets = p.box(1170, 530, 280, 90, "./secrets\ntokens, credentials", "data", typ="storedData")
+datad   = p.box(1170, 700, 280, 90, "./data\nresponses JSON archive", "data", typ="document")
+p.line(browser, auth, "http://127.0.0.1:8000/login")
+p.line(auth, redis, "single-use login nonces")
+p.line(auth, secrets, "writes token files")
+p.line(auth, engine, "healthcheck gates startup", dashed=True, color="#C2185B")
+p.line(factory, rabbit, "publishes seed URLs")
+p.line(factory, redis, "have we fetched this?", dashed=True)
+p.line(rabbit, engine, "one request at a time")
+p.line(engine, spot, "GET + bearer token")
+p.line(engine, rabbit, "responses, fanned out x3")
+p.line(rabbit, disk, "")
+p.line(rabbit, graphw, "")
+p.line(rabbit, follow, "")
+p.line(follow, rabbit, "new URLs back on the queue")
+p.line(follow, redis, "dedup check", dashed=True)
+p.line(disk, datad, "")
+p.line(graphw, neo, "MERGE nodes + edges")
+p.line(factory, neo, "discography seed query", dashed=True)
+p.line(mock, tests, "failure injection", dashed=True)
+pages.append(p)
+
+# ---------------------------------------------------------------- page 3
+p = Page("p3", "3. Inside the pipeline (C4-3)")
+env = p.note(60, 60, 360, 120,
+             'Every message is a small JSON envelope:\n'
+             '{ "request_url": "https://api.spotify.com/v1/me/tracks?offset=0",\n'
+             '  "depth_of_search": 1, "user_id": "michael" }')
+seeds  = p.box(60, 420, 220, 100, "requests_factory\nseed URLs", "py", icon="python")
+redis  = p.box(330, 160, 220, 90, "Redis\nspb:crawled_urls", "redis", icon="redis", typ="database")
+reqx   = p.box(330, 420, 230, 100, "spotify_api_requests\nqueue: make_api_call", "rabbit", icon="rabbitmq")
+engine = p.box(650, 420, 250, 110, "api_call_engine\nGET - 429 backoff -\n500 retry - 401 refresh", "py", icon="python")
+spot   = p.box(650, 150, 250, 100, "Spotify Web API", "spotify", icon="spotify")
+respx  = p.box(990, 420, 240, 100, "spotify_api_responses\n3 bound queues", "rabbit", icon="rabbitmq")
+disp   = p.box(1320, 420, 240, 110, "dispatcher\nURL pattern -> handler class\n(response_handlers/main.py)", "py")
+disk   = p.box(1650, 260, 220, 90, "write_to_disk\ndata/responses/*.json", "data", typ="document")
+graphw = p.box(1650, 430, 220, 90, "write_to_neo4j\nMERGE via Cypher", "neo", icon="neo4j", typ="database")
+follow = p.box(1650, 600, 220, 90, "follow_links\nneighbors at depth - 1", "py")
+p.line(seeds, redis, "url_is_new? (SADD)", dashed=True)
+p.line(seeds, reqx, "publish")
+p.line(reqx, engine, "consume")
+p.line(engine, spot, "GET", both=True)
+p.line(engine, respx, "response + envelope")
+p.line(respx, disp, "consume x3 workers")
+p.line(disp, disk, "")
+p.line(disp, graphw, "")
+p.line(disp, follow, "")
+p.line(follow, reqx, "album/artist URLs at depth - 1")
+p.line(follow, redis, "dedup check", dashed=True)
+pages.append(p)
+
+# ---------------------------------------------------------------- page 4
+p = Page("p4", "4. The OAuth login flow")
+steps = [
+    ("You open http://127.0.0.1:8000/login\nand click Add a user", "person", None),
+    ("/login/start mints a single-use state nonce\ninto Redis (TTL 10 min)", "redis", "redis"),
+    ("303 redirect (never cached) to Spotify's\nconsent page - you log in, click Agree", "spotify", "spotify"),
+    ("Spotify redirects back:\n/callback?code=...&state=...", "spotify", "spotify"),
+    ("Callback consumes the nonce (GETDEL -\nvalid exactly once) or rejects with 400", "redis", "redis"),
+    ("Exchanges the code for tokens\n(client id + secret)", "py", "falcon"),
+    ("Asks GET /v1/me whose token this is -\nidentity is derived, never assumed", "spotify", "spotify"),
+    ("Writes secrets/users/<their_id>/...\n(+ legacy mirror if primary user)", "data", None),
+    ("Compose healthcheck sees the token file:\nthe gate opens, the crawl starts", "py", "docker"),
+]
+prev = None
+for i, (txt, pal, icon) in enumerate(steps):
+    col, row = i % 3, i // 3
+    sid = p.box(80 + col * 480, 100 + row * 260, 380, 110, f"{i+1}. {txt}", pal, icon=icon)
+    if prev:
+        p.line(prev, sid)
+    prev = sid
+p.note(80, 880, 860, 90, "Full story, file layout, scopes table, and the primary-user mirror: docs/auth.md")
+pages.append(p)
+
+# ---------------------------------------------------------------- page 5
+p = Page("p5", "5. The graph data model")
+def circle(x, y, label, pal, w=150, h=150):
+    return p.box(x, y, w, h, label, pal, typ="circle")
+user  = circle(120, 400, "User\nid, display_name", "person")
+track = circle(560, 400, "Track\nid, name, duration_ms,\nisrc, artist_ids", "spotify")
+album = circle(560, 110, "Album\nid, name,\nrelease_date", "neo")
+artist= circle(200, 110, "Artist\nid, name,\npopularity, followers", "neo")
+genre = circle(900, 110, "Genre\nname", "ghost", w=120, h=120)
+song  = circle(950, 400, "Song\nid (ISRC or hash),\ntitle", "py")
+song2 = circle(1290, 400, "Song\n(remix parent)", "py", w=130, h=130)
+note  = circle(430, 700, "Note\ntext, at_ms", "data", w=120, h=120)
+cue   = circle(620, 700, "Cue\nat_ms, label", "data", w=120, h=120)
+sect  = circle(810, 700, "Section\nkind, start_ms,\nend_ms", "data", w=130, h=130)
+sect2 = circle(1060, 700, "Section\n(next)", "data", w=110, h=110)
+mpl   = circle(120, 700, "ManagedPlaylist\nspotify_id, generator,\ntarget_snapshots", "ai", w=160, h=160)
+p.line(user, track, "LIKED {added_at}")
+p.line(user, mpl, "HAS_MANAGED")
+p.line(album, track, "CONTAINS")
+p.line(artist, track, "CREATED")
+p.line(artist, album, "CREATED")
+p.line(artist, genre, "SPOTIFY_CLASSIFIED_AS")
+p.line(track, song, "VERSION_OF {kind, method, confidence}")
+p.line(song, song2, "REMIX_OF {confidence}")
+p.line(track, note, "HAS_NOTE")
+p.line(track, cue, "HAS_CUE")
+p.line(track, sect, "HAS_SECTION")
+p.line(sect, sect2, "NEXT (time order)")
+p.note(1180, 90, 300, 150, "Two layers:\nCatalog (Track/Album/Artist/Genre/Song) is shared - MERGEd on Spotify IDs.\nOwnership (User + LIKED / HAS_MANAGED) is per-person, on edges only.")
+pages.append(p)
+
+# ---------------------------------------------------------------- page 6
+p = Page("p6", "6. One liked song's journey")
+s1 = p.box(70, 300, 280, 120, 'Spotify answers\nGET /v1/me/tracks - one page,\n20 liked songs as JSON', "spotify", icon="spotify")
+s2 = p.box(440, 300, 280, 120, "The envelope rides RabbitMQ\n{request_url, depth: 1,\nuser_id: michael}", "rabbit", icon="rabbitmq")
+s3 = p.box(810, 300, 300, 120, "Handler:\nLikedSongsPlaylistResponseHandler\n(one class per endpoint)", "py", icon="python")
+s4 = p.box(1210, 120, 300, 100, "Disk: data/responses/\nliked_songs/michael/0.json", "data", typ="document")
+s5 = p.box(1210, 310, 300, 110, "Graph: MERGE Track, Album,\nArtist + LIKED, CONTAINS,\nCREATED edges", "neo", icon="neo4j", typ="database")
+s6 = p.box(1210, 510, 300, 100, "Follow: album + artist URLs\nqueued at depth - 1", "py")
+p.line(s1, s2); p.line(s2, s3)
+p.line(s3, s4); p.line(s3, s5); p.line(s3, s6)
+p.note(70, 520, 640, 200,
+       'The fact "you liked it on 2023-10-15" lands on the LIKED edge (a fact about you).\n'
+       '"The song is 3:20 long" lands on the Track (a fact about the world).\n\n'
+       "MERGE on stable Spotify IDs means a re-crawl updates in place - nothing duplicates.\n"
+       "x 12,547 tracks: the first full crawl took about 18 minutes.")
+p.note(70, 90, 640, 150,
+       '{ "added_at": "2023-10-15T14:22:00Z",\n'
+       '  "track": { "id": "0VjIjW4GlUZAMYd2vXMwbk", "name": "Blinding Lights",\n'
+       '             "external_ids": {"isrc": "USUG11904206"},\n'
+       '             "album": {"name": "After Hours"}, "artists": [{"name": "The Weeknd"}] } }')
+pages.append(p)
+
+# ---------------------------------------------------------------- page 7
+p = Page("p7", "7. Delivery paths")
+src   = p.box(80, 340, 240, 100, "Source checkout\n(GitHub: source hosting only -\nno CI, no cloud)", "plain")
+build = p.box(430, 340, 300, 110, "docker compose build\nONE image: spotify-power-browser\npython:3.13-slim + Poetry deps", "py", icon="docker")
+live  = p.box(850, 90, 300, 100, "Live crawl\ndocker compose up\n(pauses at the OAuth gate)", "spotify", icon="spotify")
+testr = p.box(850, 260, 300, 100, "Test suite\ndocker compose run --rm tests", "py", icon="pytest")
+mockr = p.box(850, 430, 300, 110, "Offline mock crawl\ncompose -f compose.yaml\n-f docker-compose.mock.yml up", "ghost")
+mcpr  = p.box(850, 620, 300, 100, "MCP server (on demand)\nscripts/mcp_server.sh\ndocker run --rm -i", "py", icon="anthropic")
+wt    = p.note(430, 620, 340, 140, "Worktree isolation (SessionStart hook):\neach checkout gets its own IMAGE_TAG +\ncompose project, no host ports.\nLive crawls: primary checkout only.")
+aws   = p.box(1290, 340, 280, 130, "AWS (planned, not built)\nmock service first on Fargate,\nthen the real pipeline\ndocs/mock-spotify-service.md", "ghost", dashed=True, typ="cloud")
+p.line(src, build)
+p.line(build, live); p.line(build, testr); p.line(build, mockr); p.line(build, mcpr)
+p.line(build, aws, "someday", dashed=True)
+pages.append(p)
+
+# ---------------------------------------------------------------- page 8
+p = Page("p8", "8. Monitoring map: which window answers which question")
+qs = [
+    ("Is it making progress?", 80),
+    ("Is it done?", 380),
+    ("Erroring or rate-limited?", 680),
+    ("What has it fetched?", 980),
+    ("Is data landing in the graph?", 1280),
+]
+qids = [p.box(x, 80, 260, 90, q, "note", typ="decision") for q, x in qs]
+rmq  = p.box(80, 350, 260, 120, "RabbitMQ UI :15672\nQueues tab: backlog + rates.\nEmpty + zero rates = done", "rabbit", icon="rabbitmq")
+logs = p.box(380, 350, 260, 120, "docker compose logs -f\napi_call_engine: GETs, 429s,\ntoken refreshes", "py", typ="document")
+red  = p.box(680, 350, 260, 120, "Redis\nSCARD spb:crawled_urls\n= URLs fetched ever", "redis", icon="redis", typ="database")
+disk = p.box(980, 350, 260, 120, "data/responses/\nfind ... | wc -l\none JSON per resource", "data", typ="document")
+neo  = p.box(1280, 350, 260, 120, "Neo4j browser\nMATCH (t:Track)\nRETURN count(t)", "neo", icon="neo4j", typ="database")
+for q, t in zip(qids, [rmq, logs, red, disk, neo]):
+    p.line(q, t)
+p.line(qids[0], logs, "", dashed=True)
+p.line(qids[3], red, "", dashed=True)
+p.note(80, 560, 700, 130, "Gaps to know about: no metrics/dashboards, no alerting, no completion\nsignal (queues empty IS done), plain-text logs lost on compose down.\nDetails + a healthy-crawl timeline: docs/observability.md")
+pages.append(p)
+
+# ---------------------------------------------------------------- page 9
+p = Page("p9", "9. Test coverage map")
+suite = p.container(60, 100, 700, 720, "Test suite: docker compose run --rm tests", "py", icon="pytest")
+unit  = p.box(120, 180, 280, 110, "Pure unit tests\nconfig, dispatch, batching,\nnormalization, models", "py")
+integ = p.box(120, 350, 280, 110, "Integration tests\noauth, refresh, dedup,\nqueues, MCP tools", "py")
+e2e   = p.box(120, 520, 280, 110, "End-to-end tests\ncrawl -> handler -> graph\n(incl. two-user multiplayer)", "py")
+resil = p.box(430, 350, 280, 110, "Resilience tests\n429 / 401 / 500 injection,\nconsumer reconnect", "py")
+guard = p.note(430, 520, 290, 170, "Safety rails:\nsecrets mounted read-only;\nautouse fixture fails any test\nthat changes real secrets;\ntmp_path token stores")
+mock  = p.box(880, 140, 260, 100, "spotify_mock\nfake Spotify +\nfailure injection", "ghost", icon="falcon")
+red   = p.box(880, 310, 260, 90, "Redis", "redis", icon="redis", typ="database")
+rmq   = p.box(880, 460, 260, 90, "RabbitMQ", "rabbit", icon="rabbitmq")
+neo   = p.box(880, 610, 260, 100, "host Neo4j Desktop\n(tests skip politely if down)", "neo", icon="neo4j", typ="database")
+p.line(integ, mock); p.line(integ, red); p.line(integ, rmq)
+p.line(e2e, mock); p.line(e2e, neo); p.line(e2e, red)
+p.line(resil, mock); p.line(resil, red)
+pages.append(p)
+
+# ---------------------------------------------------------------- page 10
+p = Page("p10", "10. Exploring the graph through MCP")
+you   = p.box(70, 300, 200, 90, "You:\n'who should I\nlisten to next?'", "person", typ="circle")
+client= p.box(360, 300, 270, 100, "Claude Desktop / Claude Code\n(MCP client)", "ai", icon="anthropic")
+sh    = p.box(720, 300, 260, 100, "scripts/mcp_server.sh\nregistered in .mcp.json /\ndesktop config", "plain", typ="document")
+srv   = p.box(1070, 300, 270, 110, "mcp_server\ndocker run --rm -i\nstdio, read-only", "py", icon="docker")
+neo   = p.box(1450, 300, 260, 110, "Neo4j Desktop\nhost.docker.internal:7687", "neo", icon="neo4j", typ="database")
+p.line(you, client, "", both=True)
+p.line(client, sh, "launches")
+p.line(sh, srv, "")
+p.line(client, srv, "MCP tools over stdio", both=True)
+p.line(srv, neo, "read-only Cypher\nrow cap 200 - timeout 30s")
+p.note(360, 520, 700, 170,
+       "Tools: graph_schema - find_artist - find_track - collaborators_of -\n"
+       "discover_adjacent - artist_completeness - run_cypher_readonly (escape hatch)\n"
+       "Resources: schema://graph, queries://cookbook (incl. the two-user overlap pack)\n"
+       "Guards: Neo4j READ_ACCESS sessions + write-keyword scan + row cap + timeout")
+p.note(1070, 520, 340, 120,
+       "ChatGPT Desktop: not supported -\nremote-HTTP-only client vs this local\nstdio server (mcp_server/README.md)")
+pages.append(p)
+
+doc = {"version": 1, "pages": [pg.d for pg in pages]}
+out = json.dumps(doc, separators=(",", ":"))
+with open("spb_lucid.json", "w") as f:
+    f.write(out)
+print(f"pages={len(pages)} shapes={sum(len(pg.d['shapes']) for pg in pages)} "
+      f"lines={sum(len(pg.d['lines']) for pg in pages)} bytes={len(out)}")

--- a/docs/exploring-the-graph.md
+++ b/docs/exploring-the-graph.md
@@ -1,0 +1,176 @@
+# Exploring the graph: a field guide
+
+The crawl is done. There are twelve thousand tracks in Neo4j. **Now what?**
+
+This is the guide for that moment. It assumes you know a little Cypher (or are
+willing to paste queries and tweak numbers) and nothing else. Two ways to
+explore: hand-written queries in the Neo4j browser (this page), or
+conversationally through an AI assistant
+([mcp_server/README.md](../mcp_server/README.md) — same graph, natural
+language instead of Cypher).
+
+## Getting your bearings (5 minutes)
+
+Open the Neo4j browser (Neo4j Desktop → your database → Open). First, see
+what exists:
+
+```cypher
+CALL db.labels();            // the node types
+CALL db.relationshipTypes(); // the edge types
+```
+
+Then size it up:
+
+```cypher
+MATCH (t:Track)  WITH count(t) AS tracks
+MATCH (al:Album) WITH tracks, count(al) AS albums
+MATCH (ar:Artist) WITH tracks, albums, count(ar) AS artists
+MATCH (u:User)
+RETURN tracks, albums, artists, collect(u.id) AS users;
+```
+
+And look at one familiar corner — pick any artist you love:
+
+```cypher
+MATCH (a:Artist {name: "Caribou"})-[:CREATED]->(t:Track)
+RETURN a, t LIMIT 50;
+```
+
+The browser draws the neighborhood. Click nodes, expand relationships, get a
+feel for the shape: Artists point at Tracks and Albums via `CREATED`, Albums
+point at Tracks via `CONTAINS`, you point at Tracks via `LIKED`. (The full
+model, with stories: [data-model.md](data-model.md).)
+
+**The one mental shift from tables to graphs:** you don't join — you draw the
+shape you're looking for. "Artists I like who share a genre with Caribou" is
+literally the path `(me)-[:LIKED]->()<-[:CREATED]-(artist)-[:SPOTIFY_CLASSIFIED_AS]->(genre)<-[:SPOTIFY_CLASSIFIED_AS]-(caribou)`.
+
+## Ten questions worth asking your own library
+
+Each of these is copy-pasteable. Replace names and numbers freely — breaking
+these queries is the tutorial.
+
+**1. Who do I actually listen to?** (by liked-track count)
+
+```cypher
+MATCH (u:User {id: "YOUR_ID"})-[:LIKED]->(t:Track)<-[:CREATED]-(a:Artist)
+RETURN a.name, count(t) AS liked_tracks
+ORDER BY liked_tracks DESC LIMIT 25;
+```
+
+**2. What do I sound like?** (genre profile)
+
+```cypher
+MATCH (u:User {id: "YOUR_ID"})-[:LIKED]->(t)<-[:CREATED]-(a:Artist)
+      -[:SPOTIFY_CLASSIFIED_AS]->(g:Genre)
+RETURN g.name, count(DISTINCT t) AS tracks
+ORDER BY tracks DESC LIMIT 30;
+```
+
+**3. How has my taste moved over time?** (`added_at` lives on the LIKED edge)
+
+```cypher
+MATCH (u:User {id: "YOUR_ID"})-[l:LIKED]->(t)
+RETURN substring(l.added_at, 0, 4) AS year, count(t) AS songs_liked
+ORDER BY year;
+```
+
+**4. My deep cuts** — liked artists almost nobody follows:
+
+```cypher
+MATCH (u:User {id: "YOUR_ID"})-[:LIKED]->(t)<-[:CREATED]-(a:Artist)
+WHERE a.popularity IS NOT NULL AND a.popularity < 25
+RETURN a.name, a.popularity, count(t) AS my_likes
+ORDER BY my_likes DESC LIMIT 25;
+```
+
+(If `popularity` is null everywhere, run the enrichment first:
+`python -m application.discovery.backfill_artists` — see
+[application/discovery/README.md](../application/discovery/README.md).)
+
+**5. Who's hiding one hop away?** Artists you've *never* liked who
+collaborated with several artists you love — your discovery frontier:
+
+```cypher
+MATCH (u:User {id: "YOUR_ID"})-[:LIKED]->()<-[:CREATED]-(mine:Artist)
+WITH u, collect(DISTINCT mine) AS my_artists
+UNWIND my_artists AS m
+MATCH (m)-[:CREATED]->(t:Track)<-[:CREATED]-(candidate:Artist)
+WHERE NOT candidate IN my_artists
+WITH candidate, count(DISTINCT m) AS bridges, collect(DISTINCT m.name)[0..3] AS via
+WHERE bridges >= 2
+RETURN candidate.name, candidate.popularity, bridges, via
+ORDER BY bridges DESC, candidate.popularity ASC LIMIT 25;
+```
+
+This is the query behind the whole discovery feature; the polished versions
+live in [queries/discovery/](../application/graph_database/queries/discovery/)
+and power the `adjacent-discoveries` playlist.
+
+**6. Same song, how many times?** (after a mastering run — see
+[application/mastering/README.md](../application/mastering/README.md))
+
+```cypher
+MATCH (s:Song)<-[v:VERSION_OF]-(t:Track)
+WITH s, count(t) AS versions, collect(t.name) AS names
+WHERE versions > 1
+RETURN s.title, versions, names
+ORDER BY versions DESC LIMIT 20;
+```
+
+**7. Which albums do I love whole vs. cherry-pick?**
+
+```cypher
+MATCH (u:User {id: "YOUR_ID"})-[:LIKED]->(t)<-[:CONTAINS]-(al:Album)
+WITH al, count(t) AS liked, al.total_tracks AS total
+WHERE total > 4
+RETURN al.name, liked, total, toFloat(liked)/total AS ratio
+ORDER BY ratio DESC, liked DESC LIMIT 25;
+```
+
+**8–10.** Longest liked tracks; remixes and their parents
+(`MATCH (r:Song)-[:REMIX_OF]->(p:Song) RETURN r.title, p.title`); everything
+you annotated (`MATCH (t:Track)-[:HAS_CUE|HAS_NOTE|HAS_SECTION]->(x) RETURN t.name, x`).
+
+## The shared music space (when a friend's library is loaded)
+
+Once a second user is crawled ([multiplayer-runbook.md](multiplayer-runbook.md)),
+the interesting object is the *overlap*. Five ready-made queries live in
+[queries/overlap/](../application/graph_database/queries/overlap/) — they use
+parameters, so set them once in the browser:
+
+```
+:param a => "YOUR_ID"
+:param b => "THEIR_ID"
+:param min_likes => 3
+:param min_bridges => 2
+```
+
+Then open any file from that directory, paste, run:
+
+| Query file | The question it answers |
+|---|---|
+| `shared_artists_weighted.cypher` | *Which artists do we both like — and both actually keep coming back to?* Ranked by the smaller of the two like-counts, so one-sided obsessions sink. |
+| `liked_artist_jaccard.cypher` | *How similar are we, as one number?* 0 = nothing in common, 1 = identical artist sets. Library-size-normalized, so a huge library vs a small one is compared fairly. |
+| `genre_radar_diff.cypher` | *Where do our genre profiles diverge most?* Shares, not raw counts. |
+| `a_loves_b_never_heard.cypher` | *What do I love that you've never touched?* The "here's your homework" query — swap `$a`/`$b` to get homework in the other direction. |
+| `bridge_playlist.cypher` | *What's new to __both__ of us but adjacent to __both__ our tastes?* Finds artists neither of you knows who collaborated with several artists each of you loves. The best first-date query in the pack. |
+
+A nice session structure for exploring with the friend in the room:
+**jaccard** first (one number to react to), **shared_artists_weighted** second
+(the "obviously" and the "wait, you too?!" moments), **genre_radar_diff**
+third (why you feel different), then **a_loves_b_never_heard** both directions
+(exchange homework), and **bridge_playlist** last — pipe its output into a
+real playlist with the `blend` generator
+([application/playlists/README.md](../application/playlists/README.md)).
+
+## Escalation paths when a question outgrows the browser
+
+- **Repeatable analysis** → the query packs under
+  [application/graph_database/queries/](../application/graph_database/queries/)
+  are the curated, tested versions of everything above. Steal from them.
+- **Conversational exploration** → the MCP server exposes `run_cypher_readonly`
+  plus purpose-built tools (`find_artist`, `collaborators_of`,
+  `discover_adjacent`) to Claude. You ask in English; it writes the Cypher.
+- **Acting on findings** → the playlist generators turn queries into actual
+  Spotify playlists, safely (dry-run default, managed-only writes).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,136 @@
+# Observability: watching a crawl run
+
+There is no dashboard. There *are* five good windows into a running system,
+and knowing which one answers which question is most of the skill. This page
+is the field guide; the honest list of gaps is at the bottom.
+
+```mermaid
+flowchart TB
+    q1{{"❓ Is it making progress?"}}
+    q2{{"❓ Is it done?"}}
+    q3{{"❓ Is it erroring / rate-limited?"}}
+    q4{{"❓ What has it fetched so far?"}}
+    q5{{"❓ Is the data landing in the graph?"}}
+
+    rmq["🐰 RabbitMQ UI<br/>localhost:15672 (guest/guest)<br/>Queues tab: backlog + msg rates"]
+    logs["📜 docker compose logs -f<br/>api_call_engine (GETs, 429s, refreshes)<br/>responses_write_to_neo4j (inserts)"]
+    redis["🧠 Redis<br/>SCARD spb:crawled_urls<br/>= URLs fetched ever"]
+    disk["📄 data/responses/<br/>find … -name '*.json' | wc -l"]
+    neo["🕸️ Neo4j browser<br/>MATCH (t:Track) RETURN count(t)"]
+
+    q1 --> rmq
+    q1 --> logs
+    q2 --> rmq
+    q3 --> logs
+    q4 --> redis
+    q4 --> disk
+    q5 --> neo
+```
+
+---
+
+## Window 1: the RabbitMQ management UI (your main gauge)
+
+Open **http://localhost:15672**, log in `guest`/`guest`, go to the **Queues**
+tab. You'll see the four queues; how to read them:
+
+| Queue | Meaning of a growing backlog |
+|---|---|
+| `make_api_call` | Normal mid-crawl. This is the frontier — every URL still to fetch. It grows while `follow_links` discovers faster than the engine fetches (it always does), then drains. |
+| `write_to_disk` / `write_to_neo4j` | Should stay near zero — these workers are faster than the engine feeds them. A persistent backlog here means that worker is stuck (check its logs). |
+| `follow_links` | Same: near zero is healthy. |
+
+**Reading the rates:** the *Message rates* columns are the pulse. Publish ≈
+deliver ≈ ack, all above zero → healthy crawl. **All rates at zero and all
+queues empty → the crawl is finished.** That's the completion signal; nothing
+announces it.
+
+**Common pattern:** `make_api_call` has messages but its deliver rate is ~0
+for minutes → the engine is sleeping through a `429` backoff. Confirm in the
+engine log.
+
+## Window 2: the logs
+
+Logs go to container stdout (plain text, no files on disk), so `docker
+compose logs` is the whole story:
+
+```bash
+docker compose logs -f api_call_engine            # every GET as it happens
+docker compose logs -f responses_write_to_neo4j   # inserts landing in the graph
+docker compose logs --since 10s api_call_engine | grep -c 'GET:'   # throughput; 0 = idle
+```
+
+What to look for in the engine log:
+
+- `GET: https://…` — the steady heartbeat. Silence means idle or backoff.
+- `429` + a sleep message — rate-limited. Normal in bursts; the sleep is
+  capped at 10 minutes no matter what Spotify asks for.
+- `401` + `refreshing` — the hourly token refresh. Should succeed quietly;
+  a refresh *failure* means your grant was revoked → re-login.
+- Repeated reconnect messages — the broker connection dropped; the loop
+  reconnects on its own. Occasional is fine, constant is a problem.
+
+## Window 3: Redis (what's been fetched)
+
+```bash
+docker compose exec redis redis-cli SCARD spb:crawled_urls        # catalog URLs ever fetched
+docker compose exec redis redis-cli KEYS 'spb:crawled_urls:*'     # per-user sets (multiplayer)
+```
+
+The set persists across runs (that's the point — it's why a second `up`
+doesn't re-crawl). Watching `SCARD` climb is the crudest possible progress
+bar, but it works.
+
+## Window 4: the disk archive
+
+```bash
+find data/responses -name '*.json' | wc -l
+du -sh data/responses
+```
+
+One JSON file per fetched resource, organized by endpoint
+(`liked_songs/<user>/`, `tracks/`, `albums/`, …). Doubles as the audit trail
+when you wonder "what exactly did Spotify return for this album?"
+
+## Window 5: the Neo4j browser (the point of it all)
+
+```cypher
+MATCH (t:Track) RETURN count(t);                       // watch it climb mid-crawl
+MATCH (u:User)-[:LIKED]->(t) RETURN u.id, count(t);    // per-user library sizes
+MATCH (a:Artist) WHERE a.popularity IS NULL
+RETURN count(a);                                       // artists awaiting enrichment
+```
+
+Inserts are visible immediately — there's no batching delay between the
+pipeline and the database.
+
+---
+
+## A healthy crawl, as a timeline
+
+1. **Minute 0:** `up`; RabbitMQ and Redis go healthy; everything else waits on
+   the auth gate. *You log in.*
+2. **Minutes 1–3:** `make_api_call` backlog balloons (liked-songs pages fan
+   out into thousands of album/artist follows). This looks alarming and is
+   normal.
+3. **Steady state:** backlog drains at the engine's pace. Expect occasional
+   429 pauses.
+4. **Done:** rates flatline at zero, queues empty. For reference, the first
+   full crawl (≈12.5k tracks, batching on) took **~18 minutes** end to end.
+
+## The gaps (things you might expect and won't find)
+
+- **No metrics or dashboards.** No Prometheus, no Grafana. The RabbitMQ UI is
+  the only live gauge, and it doesn't keep history.
+- **No alerting.** A wedged crawl doesn't page you; you notice by looking.
+- **No completion signal.** "Queues empty + rates zero" is the definition of
+  done.
+- **Plain-text logs, lost on `down`.** A structured (JSON) formatter exists in
+  `application/loggers.py` but is switched off; logs live only in the
+  container's buffer.
+- **No tracing.** You can't follow one URL's journey across services except by
+  grepping logs for it.
+
+For a personal, watch-it-run project these are reasonable trade-offs; the
+first two would matter the moment this runs unattended in the cloud
+([delivery.md](delivery.md)).

--- a/docs/plans/05-graph-mcp-server.md
+++ b/docs/plans/05-graph-mcp-server.md
@@ -51,7 +51,7 @@ curated Cypher pack — same files as `application/graph_database/queries/`).
 Discover Weekly) hits the 2024-11 restriction on algorithmic/editorial
 playlists *for new apps*. Whether this 2023 app is grandfathered is **unknown —
 probe it** (one GET of the Release Radar playlist id with the live token;
-extend `_probe_api_surface.py`). If blocked: the fallback is "Like the songs
+extend `scripts/probes/probe_api_surface.py`). If blocked: the fallback is "Like the songs
 you care about / add to a personal playlist" → personal playlists read fine.
 
 ### Registration

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -24,7 +24,7 @@ Effort legend: **S** ≤1 day · **M** 2–4 days · **L** 1–2 weeks · **XL**
 
 Spotify's 2024-11-27 policy removed several endpoints for new apps; the 2026-02
 changelog targeted (then postponed) the batch endpoints. This app (created
-2023-04) was probed with a live token via `_probe_api_surface.py`:
+2023-04) was probed with a live token via `scripts/probes/probe_api_surface.py`:
 
 | Endpoint | Result | Meaning for the plans |
 |----------|--------|----------------------|
@@ -38,7 +38,7 @@ changelog targeted (then postponed) the batch endpoints. This app (created
 
 A 403 **without** a message body = removed-for-this-app; a 403 **with**
 "Insufficient client scope" = endpoint alive, token lacks the scope. Re-probe
-any of this with `_probe_api_surface.py` before building on it.
+any of this with `scripts/probes/probe_api_surface.py` before building on it.
 
 ## Do these first (shared foundations)
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -6,17 +6,17 @@ and delegation-ready: hand one to a coding agent with this README for context._
 
 ## The plans
 
-| # | Plan | One-liner | Effort |
+| # | Plan | One-liner | Status |
 |---|------|-----------|--------|
-| 01 | [Adjacent-artist discovery](01-adjacent-artist-discovery.md) | Find unknown artists two collab-hops from your taste | M–L |
-| 02 | [Listening completeness](02-listening-completeness.md) | Full listening history + "how much of this artist have I really heard?" | M + waiting |
-| 03 | [Entity mastering](03-entity-mastering.md) | Roll deluxe/single/clean-explicit re-releases into canonical Songs | M |
-| 04 | [Annotations & DJ sets](04-annotations-and-dj-sets.md) | Timestamped song notes → DJ set planning → performance HUD | XL (phased) |
-| 05 | [Graph MCP server](05-graph-mcp-server.md) | Let AI query your taste graph with purpose-built tools | S–M |
-| 06 | [Multiplayer](06-multiplayer.md) | Two users, one graph — intersect and diff musical taste | L |
-| 07 | [Beyond Spotify](07-beyond-spotify.md) | Local files + SoundCloud in one platform-agnostic graph | XL (phased) |
-| 08 | [Playlist write-back](08-playlist-writeback.md) _(bonus)_ | Every insight becomes a real Spotify playlist | S–M |
-| 09 | [Taste over time](09-taste-over-time.md) _(bonus)_ | Your musical eras, drift, and year-in-review from timestamps you already have | S–M |
+| 01 | [Adjacent-artist discovery](01-adjacent-artist-discovery.md) | Find unknown artists two collab-hops from your taste | **Shipped** (PR #22) |
+| 02 | [Listening completeness](02-listening-completeness.md) | Full listening history + "how much of this artist have I really heard?" | Pending — blocked on the streaming-history export |
+| 03 | [Entity mastering](03-entity-mastering.md) | Roll deluxe/single/clean-explicit re-releases into canonical Songs | **Shipped** (PR #20) |
+| 04 | [Annotations & DJ sets](04-annotations-and-dj-sets.md) | Timestamped song notes → DJ set planning → performance HUD | **Phases A+B shipped** (PR #21); C+D pending |
+| 05 | [Graph MCP server](05-graph-mcp-server.md) | Let AI query your taste graph with purpose-built tools | **Shipped** (PR #19) |
+| 06 | [Multiplayer](06-multiplayer.md) | Two users, one graph — intersect and diff musical taste | **Shipped** (PR #24) |
+| 07 | [Beyond Spotify](07-beyond-spotify.md) | Local files + SoundCloud in one platform-agnostic graph | Pending (XL, phased) |
+| 08 | [Playlist write-back](08-playlist-writeback.md) | Every insight becomes a real Spotify playlist | **Shipped** (PR #23) |
+| 09 | [Taste over time](09-taste-over-time.md) | Your musical eras, drift, and year-in-review from timestamps you already have | Pending |
 
 Effort legend: **S** ≤1 day · **M** 2–4 days · **L** 1–2 weeks · **XL** multi-week, phased.
 
@@ -52,8 +52,7 @@ any of this with `scripts/probes/probe_api_surface.py` before building on it.
 3. **ISRC + popularity enrichment backfill** (plans 03 §T1–T3, 01 §T2): ~500
    batch calls total, minutes of runtime, and nearly every plan's data quality
    improves. Do it before the next big crawl.
-4. **Merge PR #16 first** (token-refresh client-auth fix) — every crawl longer
-   than ~1h dies without it.
+4. ~~Merge PR #16 first~~ — merged; token refresh carries client auth now.
 
 ## Dependency map
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,98 @@
+# Testing: what's covered and how to read the suite
+
+The suite is ~37 files under [tests/](../tests/). This page explains how it's
+organized, how to run it, why it can't hurt your real data, and where the gaps
+are. The per-file inventory lives in [tests/README.md](../tests/README.md).
+
+```mermaid
+flowchart TB
+    subgraph suite ["🧪 The test suite (docker compose run --rm tests)"]
+        unit["🔬 Pure unit tests<br/>config, dispatch, batching,<br/>normalization, models<br/>— no services needed"]
+        integ["🔗 Integration tests<br/>oauth, refresh, dedup,<br/>queues, MCP tools"]
+        e2e["🛤️ End-to-end tests<br/>crawl → handler → graph:<br/>liked songs, discovery,<br/>mastering, multiplayer"]
+        resil["🛡️ Resilience tests<br/>429 / 401 / 500 injection,<br/>consumer reconnect"]
+    end
+
+    subgraph services ["What they lean on (skip politely if absent)"]
+        mock["🎭 spotify_mock<br/>fake Spotify + failure injection"]
+        redis["🧠 Redis"]
+        rmq["🐰 RabbitMQ"]
+        neo["🕸️ host Neo4j Desktop"]
+    end
+
+    guard["🔒 Safety rails:<br/>secrets mounted read-only ·<br/>autouse fixture fails any test<br/>that changes real secrets ·<br/>tmp_path token stores"]
+
+    integ --> mock & redis & rmq
+    e2e --> mock & neo & redis
+    resil --> mock & redis
+    suite --- guard
+```
+
+## How to run it
+
+```bash
+docker compose run --rm tests                                   # everything
+docker compose run --rm tests python3 -m pytest tests/test_engine_resilience.py -v   # one file
+docker compose run --rm tests python3 -m pytest tests/ -k "mastering" -v             # one topic
+```
+
+The command brings up RabbitMQ, Redis, and the mock automatically (compose
+dependencies). Tests that need the host Neo4j Desktop **skip** if it isn't
+running — skips are normal, failures are not. It's safe to run during a live
+crawl *from a worktree checkout* (isolated stack); from the primary checkout
+the suite would share the crawl's RabbitMQ and Redis.
+
+## The four layers, and how to read them
+
+**1. Pure unit tests** (`test_config`, `test_dispatcher`, `test_batch_handler`,
+`test_mastering_normalize`, `test_annotations_model`, …). No services; they
+pin down decisions in pure functions. Read these first when you want to know
+"what is the rule?" — e.g. `test_mastering_normalize.py` is effectively the
+spec for which title suffixes get stripped.
+
+**2. Integration tests** (`test_oauth_service`, `test_refresh_token`,
+`test_redis_dedup`, `test_rabbitmq`, `test_mcp_server_*`, …). One real service
+plus real code. Read these to learn a component's contract — e.g.
+`test_redis_dedup.py` shows exactly how per-user vs shared dedup sets behave.
+
+**3. End-to-end tests** (`test_e2e_crawl`, `test_discovery_e2e`,
+`test_multiplayer_e2e`, `test_mastering_e2e`). A crawl response flows through
+real handlers into a real graph. `test_multiplayer_e2e.py` is the best
+narrative read in the suite: two users crawl, overlap queries run, migrations
+apply — the whole multiplayer story in one file.
+
+**4. Resilience tests** (`test_engine_resilience`,
+`test_engine_consumer_resilience`, `test_engine_multiuser`). These encode the
+hard-won lessons of live crawls. The mock is told to fail on command
+(`POST /_control/config {"fail_next_n": 1, "fail_status": 429}`), and the
+tests assert the engine backs off with a cap, refreshes on 401, rolls back the
+dedup mark when it gives up, and reconnects when the broker connection drops.
+Each of these corresponds to a real incident that once killed a crawl.
+
+## Why the suite can't hurt your real data
+
+Three independent rails, because one failed once:
+
+1. **Read-only mount.** Compose mounts `./secrets:ro` into the test
+   container — a stray write is a loud `OSError`, not a silent overwrite.
+2. **A tripwire fixture.** `conftest.py` snapshots the real `secrets/` before
+   every test and fails the test if anything changed. This exists because a
+   refresh-token test once silently replaced live tokens (fixed in PR #27).
+3. **tmp_path token stores.** Auth tests monkeypatch every token path into a
+   throwaway directory.
+
+Graph-touching tests use prefixed fixture data (e.g. `MCPTEST…`) and purge
+exactly that data — they share your real Neo4j instance but not your real
+nodes.
+
+## Known gaps
+
+- **No CI** — the suite only runs when someone runs it ([delivery.md](delivery.md)).
+- **No equivalence test** between `USE_BATCH_ENDPOINTS=true` and `false`
+  crawl results.
+- **Single-failure injection only** — no test throws 429+500+401 chaos
+  simultaneously.
+- **Query performance** is untested; overlap/discovery queries are verified
+  for correctness on small seed graphs only.
+- The two unimplemented handlers (`my_followed_playlists`,
+  `my_followed_artists`) have no tests because they have no code (plan 02).

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -1,28 +1,37 @@
 # spotify-graph MCP server
 
-A **read-only** MCP server that lets AI clients (Claude Code, Claude Desktop)
-query the Neo4j taste graph through purpose-built tools — plan
-[05](../docs/plans/05-graph-mcp-server.md). It runs over **stdio inside the
-project Docker image** (write once, run everywhere) and talks to Neo4j Desktop
-on the host, exactly like the `responses_write_to_neo4j` compose service.
+A **read-only** MCP server that lets an AI assistant query your Neo4j taste
+graph — you ask questions in English, it writes the Cypher. It runs over
+**stdio inside the project Docker image** and talks to Neo4j Desktop on the
+host, exactly like the `responses_write_to_neo4j` compose service.
+
+```mermaid
+flowchart LR
+    you(["🧑‍🎤 You:<br/>“who should I<br/>listen to next?”"])
+    client["🤖 Claude Desktop /<br/>Claude Code"]
+    sh["📜 scripts/mcp_server.sh"]
+    srv["🔌 mcp_server<br/>docker run --rm -i<br/>(stdio, read-only)"]
+    neo[("🕸️ Neo4j Desktop<br/>host.docker.internal:7687")]
+
+    you <--> client
+    client -- "launches via .mcp.json /<br/>desktop config" --> sh
+    sh --> srv
+    client <-- "MCP tools over stdio" --> srv
+    srv -- "read-only Cypher<br/>row cap · timeout" --> neo
+```
 
 ## Setup
 
-1. Build the image once: `docker compose build` (installs the `mcp` SDK and
-   copies `mcp_server/` in).
-2. Have Neo4j Desktop running with `secrets/neo4j_credentials.yaml` in place
+1. Build the image once: `docker compose build`.
+2. Have Neo4j Desktop running, with `secrets/neo4j_credentials.yaml` in place
    (the server starts fine without it; the first tool call needs it).
 
-### Claude Code
+**Claude Code** — nothing to do. The project-root [.mcp.json](../.mcp.json)
+registers the server; a fresh session in this repo picks it up.
 
-Nothing to do — the project-root [`.mcp.json`](../.mcp.json) registers the
-server via [`scripts/mcp_server.sh`](../scripts/mcp_server.sh); a fresh session
-in this repo picks it up automatically.
-
-### Claude Desktop
-
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json`
-(macOS), with the absolute path to your checkout:
+**Claude Desktop** — add to
+`~/Library/Application Support/Claude/claude_desktop_config.json` (macOS),
+with the absolute path to your checkout:
 
 ```json
 {
@@ -35,44 +44,68 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`
 }
 ```
 
+**ChatGPT Desktop — currently a gap.** ChatGPT's connector system only talks
+to *remote* MCP servers over HTTP(S); it cannot launch a local stdio process
+the way Claude clients can. Making this work would mean wrapping the server
+in an HTTP gateway (e.g. an MCP stdio→HTTP proxy) and exposing it through a
+tunnel — technically possible, but that publishes a doorway to your personal
+listening data, so it isn't provided here. If ChatGPT support matters, the
+clean path is adding a `streamable-http` transport option to `server.py` and
+running it only on localhost networks that ChatGPT can reach.
+
+## What to ask it
+
+Good first prompts once connected: *"What does my taste graph look like?"*
+(triggers `graph_schema`), *"Find artists similar to but more obscure than
+Four Tet"* (`discover_adjacent`), *"Who has collaborated with both Caribou
+and Floating Points?"* (`collaborators_of`), or anything ad hoc — the model
+falls back to writing Cypher through `run_cypher_readonly`. A guided tour of
+worthwhile questions: [docs/exploring-the-graph.md](../docs/exploring-the-graph.md).
+
 ## Tools (v1)
 
 | Tool | Signature | Notes |
 |------|-----------|-------|
-| `graph_schema` | `()` | Live labels / rel types / patterns / properties / counts — call first |
+| `graph_schema` | `()` | Live labels / rel types / patterns / counts — call first |
 | `run_cypher_readonly` | `(query, params?)` | Escape hatch; write clauses rejected, rows capped, timeout |
-| `find_artist` / `find_track` | `(name, limit=25)` | Fuzzy CONTAINS lookup; resolve exact names for the tools below |
+| `find_artist` / `find_track` | `(name, limit=25)` | Fuzzy lookup; resolve exact names for the tools below |
 | `collaborators_of` | `(artist_names[], limit=25)` | Shared track credits, ranked by seeds bridged |
-| `discover_adjacent` | `(seed_artist_names?, max_popularity=40, min_bridges=2, limit=50)` | Plan 01's discovery query |
-| `artist_completeness` | `(artist_name, limit=10)` | **Degraded mode**: liked-vs-catalog until plan 02 lands |
+| `discover_adjacent` | `(seed_artist_names?, max_popularity=40, min_bridges=2, limit=50)` | The adjacent-artist discovery query |
+| `artist_completeness` | `(artist_name, limit=10)` | **Degraded mode**: liked-vs-catalog until plan 02's listening history lands |
 
 Resources: `schema://graph` (live schema JSON) and `queries://cookbook`
-(the curated Cypher pack from `application/graph_database/queries/`).
+(every curated Cypher file from `application/graph_database/queries/`,
+including the two-user overlap pack — ask the assistant to read the cookbook
+and run one).
 
-Deferred: `shared_taste` needs plan 06's multi-user schema;
-`map_playlist_to_graph` needs a live probe of algorithmic-playlist access
-(plan 05 §T6) before it's worth building.
+### Current limitations
 
-### Known caveat: popularity
-
-`Artist.popularity` is **not yet populated** (plan 01's backfill adds it).
-`discover_adjacent` / `collaborators_of` treat NULL popularity as *unknown*:
-those artists are included regardless of `max_popularity`, flagged
-`popularity_unknown: true`, and sorted after known-popularity peers. Every
-payload repeats this caveat.
+- **Popularity depends on enrichment.** `Artist.popularity` is filled by
+  `python -m application.discovery.backfill_artists`; un-enriched artists
+  have NULL, are treated as *unknown* (included regardless of
+  `max_popularity`, flagged `popularity_unknown: true`), and every affected
+  payload says so.
+- **No purpose-built multi-user tool yet.** The multiplayer schema shipped
+  (plan 06), and the overlap queries are reachable via the cookbook +
+  `run_cypher_readonly`; a first-class `shared_taste(user_a, user_b)` tool is
+  the natural next addition.
+- `map_playlist_to_graph` (plan 05 §T6) still needs a live probe of
+  algorithmic-playlist access before it's worth building.
+- Results are capped (200 rows default) and queries time out (30 s default) —
+  by design; refine rather than raise.
 
 ## Read-only enforcement (belt + suspenders)
 
 1. Every session opens with `default_access_mode=READ_ACCESS`, so **Neo4j
-   itself** rejects writes — including write *procedures* a keyword scan can't
-   see (Community Edition has no RBAC; this is the enforcement point).
+   itself** rejects writes — including write *procedures* a keyword scan
+   can't see. This is the real enforcement point.
 2. A word-boundary guard rejects queries containing
    `CREATE/MERGE/DELETE/DETACH/SET/REMOVE/DROP/FOREACH/LOAD CSV` with a
    friendly error, after stripping string literals, backtick identifiers and
    comments (so `CONTAINS 'set me free'` doesn't false-positive).
-3. Row cap (`MCP_ROW_CAP`, default 200 — results carry a `truncated` flag) and
-   query timeout (`MCP_QUERY_TIMEOUT_SECONDS`, default 30) bound pathological
-   generated queries.
+3. Row cap (`MCP_ROW_CAP`, default 200 — results carry a `truncated` flag)
+   and query timeout (`MCP_QUERY_TIMEOUT_SECONDS`, default 30) bound
+   pathological generated queries.
 
 ## Environment
 
@@ -91,7 +124,7 @@ server — or bind-mount your working copy over the baked-in package while
 iterating:
 
 ```bash
-[ -f .env ] && set -a && . ./.env && set +a   # pick up a worktree's IMAGE_TAG (see compose.yaml)
+[ -f .env ] && set -a && . ./.env && set +a   # pick up a worktree's IMAGE_TAG
 docker run --rm -i \
     --add-host host.docker.internal:host-gateway \
     -e NEO4J_HOSTNAME=host.docker.internal \

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -99,10 +99,11 @@ def discover_adjacent(
     liked-songs graph. An artist qualifies with at least `min_bridges`
     independent connections and popularity at most `max_popularity`.
 
-    CAVEAT: Artist.popularity is not yet populated (plan 01 backfills it).
-    Artists with NULL popularity are treated as UNKNOWN — included regardless
-    of max_popularity, flagged popularity_unknown=true, and sorted after
-    known-popularity peers. The payload repeats this caveat.
+    CAVEAT: Artist.popularity comes from the discovery backfill
+    (python -m application.discovery.backfill_artists); artists not yet
+    enriched have NULL popularity and are treated as UNKNOWN — included
+    regardless of max_popularity, flagged popularity_unknown=true, and sorted
+    after known-popularity peers. The payload repeats this caveat.
     """
     return collaboration.discover_adjacent(
         get_driver(),

--- a/mcp_server/tools/collaboration.py
+++ b/mcp_server/tools/collaboration.py
@@ -4,17 +4,19 @@
 (verified 2026-07-06), so track-level co-credits (features, remixes, split
 EPs) ARE the discovery mechanism — see docs/plans/01-adjacent-artist-discovery.md.
 
-Popularity caveat: Artist.popularity is not yet populated (plan 01's backfill
-adds it), so most artists have popularity NULL today. NULL is treated as
-UNKNOWN — such artists are included regardless of $max_popularity and flagged
-with popularity_unknown=true, sorted after known-popularity peers.
+Popularity caveat: Artist.popularity comes from the discovery backfill
+(python -m application.discovery.backfill_artists); artists not yet enriched
+have popularity NULL. NULL is treated as UNKNOWN — such artists are included
+regardless of $max_popularity and flagged with popularity_unknown=true,
+sorted after known-popularity peers.
 """
 from mcp_server.readonly import run_readonly_query
 
 POPULARITY_CAVEAT = (
-    'Artist.popularity is not yet populated for most nodes (plan 01 backfills it). '
-    'Rows with popularity_unknown=true have no popularity data: they are included '
-    'regardless of max_popularity and sorted after known-popularity artists.'
+    'Artist.popularity is filled by the discovery backfill; artists not yet '
+    'enriched have NULL popularity. Rows with popularity_unknown=true have no '
+    'popularity data: they are included regardless of max_popularity and '
+    'sorted after known-popularity artists.'
 )
 
 # Which of the input names match no Artist node (exact, case-insensitive)?

--- a/mock_spotify/README.md
+++ b/mock_spotify/README.md
@@ -1,0 +1,51 @@
+# mock_spotify/ — a fake Spotify you can boss around
+
+A small Falcon app that impersonates both `api.spotify.com` and
+`accounts.spotify.com` well enough for the whole pipeline to run against it —
+offline, deterministic, and with failures available on demand. It exists so
+the resilience paths (429 backoff, 401 refresh, 500 give-up) can be *tested*
+instead of waited for, and so full crawls can run with no real account
+([docs/delivery.md](../docs/delivery.md#path-3-the-offline-mock-crawl)).
+
+## What it serves
+
+- **Crawl surface:** `/v1/me/tracks` (paginated, per-bearer identity),
+  single + batch tracks/albums/artists, discographies
+  (`/v1/artists/{id}/albums`, `/v1/albums/{id}/tracks`).
+- **Auth surface:** `/authorize` (round-trips your CSRF state) and
+  `/api/token` (code + refresh grants, enforcing HTTP Basic like the real
+  thing).
+- **Feature surfaces:** `/v1/me/player` (a controllable "now playing" for
+  annotation tests), `/v1/me`, playlist CRUD (create/read/update/add/remove
+  with `snapshot_id` bumps and the 100-track cap).
+
+[catalog.py](catalog.py) fabricates the data *functionally* — `trk000017`
+always reconstructs to the same track, so there's no database and every run
+is reproducible. The catalog includes deliberately tricky corners: a
+second overlapping user (`mockuser2`), a >50-album artist (forces
+pagination), frontier collaborators who exist only on discography tracks,
+and near-duplicate track variants that exercise the mastering heuristics.
+
+## The control plane
+
+```bash
+curl -X POST http://spotify_mock/_control/config \
+     -d '{"fail_next_n": 3, "fail_status": 429, "retry_after": 1}'
+curl -X POST http://spotify_mock/_control/reset      # back to clean state
+curl http://spotify_mock/_control/health
+```
+
+`fail_next_n` / `fail_url_substring` + `fail_status` inject 429/401/500 at
+will; `player_*` keys drive the fake player; `token_user` chooses which mock
+user the next login mints tokens for. This is the API the resilience tests
+lean on.
+
+## Running it
+
+As a compose service (profile-gated): `docker compose --profile mock up
+spotify_mock`, or implicitly via the tests / the mock-crawl overlay
+([docker-compose.mock.yml](../docker-compose.mock.yml)). It listens on
+port 80 inside the network at `http://spotify_mock`. Size knobs
+(`MOCK_N_TRACKS`, …) are env vars — see [catalog.py](catalog.py).
+
+Design history: [docs/mock-spotify-service.md](../docs/mock-spotify-service.md).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,9 @@
+# scripts/ — operational helpers
+
+| Script | What it does | Run it when |
+|---|---|---|
+| [mcp_server.sh](mcp_server.sh) | Launches the MCP server as `docker run --rm -i` on the shared image, wiring `host.docker.internal` → Neo4j Desktop and mounting `secrets/` read-only. Registered in [.mcp.json](../.mcp.json), so Claude runs it for you. | You normally don't — MCP clients do. |
+| [worktree_compose_env.sh](worktree_compose_env.sh) | Gives each Claude worktree its own image tag + compose project (gitignored `.env`) and strips host ports (gitignored `compose.override.yaml`). No-op outside `.claude/worktrees/`. Wired as a SessionStart hook. | Automatically, at session start. Safe by hand. |
+| [probes/](probes/) | One-off scripts that verified which Spotify endpoints this app retains post-deprecation (results tabled in [docs/plans/README.md](../docs/plans/README.md)). | Only if Spotify changes API policy again. |
+
+Background: [docs/delivery.md](../docs/delivery.md).

--- a/scripts/probes/probe_api_surface.py
+++ b/scripts/probes/probe_api_surface.py
@@ -16,7 +16,7 @@ the two. NOT part of the application; safe to delete.
     docker run --rm --add-host host.docker.internal:host-gateway \
       -e NEO4J_HOSTNAME=host.docker.internal -e PYTHONPATH=/src -w /src \
       -v "$PWD/secrets:/src/secrets" -v "$PWD:/probe" \
-      spotify-power-browser:${IMAGE_TAG:-latest} python3 /probe/_probe_api_surface.py
+      spotify-power-browser:${IMAGE_TAG:-latest} python3 /probe/scripts/probes/probe_api_surface.py
 """
 import textwrap
 import requests

--- a/scripts/probes/probe_batch_endpoints.py
+++ b/scripts/probes/probe_batch_endpoints.py
@@ -11,11 +11,11 @@ from pathlib import Path
 
 import requests
 
-ROOT = Path(__file__).absolute().parent
+ROOT = Path(__file__).absolute().parents[2]  # repo root (this file lives in scripts/probes/)
 TOKEN = (ROOT / "secrets" / "spotify_api_token.secret").read_text().strip()
 
 def ids_from_liked(n=3):
-    f = sorted(glob.glob(str(ROOT / "data/responses/liked_songs/*.json")))[0]
+    f = sorted(glob.glob(str(ROOT / "data/responses/liked_songs/**/*.json"), recursive=True))[0]
     items = json.loads(Path(f).read_text())["items"]
     return [it["track"]["id"] for it in items[:n]]
 

--- a/scripts/worktree_compose_env.sh
+++ b/scripts/worktree_compose_env.sh
@@ -1,22 +1,11 @@
 #!/usr/bin/env bash
 #
-# Per-worktree Docker Compose isolation.
-#
-# The whole project shares ONE image tag (spotify-power-browser:latest) and ONE
-# compose project name (spotify-power-browser). On a single Docker daemon that
-# means parallel Claude Code worktrees collide: a `docker compose build` in one
-# clobbers the shared :latest another is about to `run --rm tests` against, and
-# `run`/`up` share containers, networks, and the redis/mock state the tests
-# mutate.
-#
-# This gives each *Claude worktree* its own image tag + compose project by
-# writing IMAGE_TAG and COMPOSE_PROJECT_NAME into the worktree's gitignored
-# .env (compose auto-loads it). It is a deliberate NO-OP outside
-# .claude/worktrees/*, so the PRIMARY checkout keeps the shared defaults, its
-# `:latest`, and its warm redis_data volume. Live crawls (the real host Neo4j
-# graph + warm dedup) stay singular/serial there.
-#
+# Per-worktree Docker Compose isolation: writes IMAGE_TAG + COMPOSE_PROJECT_NAME
+# into the worktree's gitignored .env, and a port-stripping compose.override.yaml,
+# so parallel worktrees don't collide on one Docker daemon. Deliberate NO-OP
+# outside .claude/worktrees/* — the primary checkout keeps shared defaults.
 # Wired as a SessionStart hook in .claude/settings.json; safe to run by hand.
+# Why + details: docs/delivery.md#parallel-checkouts-the-worktree-trick
 set -euo pipefail
 
 root="${CLAUDE_PROJECT_DIR:-}"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,49 @@
+# tests/ — the suite, file by file
+
+How to run it, how it's layered, and why it can't clobber your real data:
+[docs/testing.md](../docs/testing.md). This page is the index.
+
+```bash
+docker compose run --rm tests                    # everything
+docker compose run --rm tests python3 -m pytest tests/test_dispatcher.py -v
+```
+
+## Fixtures worth knowing ([conftest.py](conftest.py))
+
+- `guard_real_secrets_untouched` (autouse) — snapshots `secrets/` before each
+  test and fails the test if anything changed. The tripwire behind PR #27.
+- `rabbitmq_channel`, `redis_client`, `neo4j_driver`, `mock_base` — connect
+  or `pytest.skip()`. Skips mean a service wasn't up; failures mean a bug.
+
+## The files, grouped
+
+**Pipeline mechanics** — `test_config` (env parsing), `test_dispatcher`
+(URL → handler routing), `test_batch_handler` (chunking/pagination/depth),
+`test_request_batch` (Spotify's 50/20/50 ID caps), `test_liked_songs`
+(response parsing), `test_rabbitmq` (queue durability flags),
+`test_redis_dedup` (shared vs per-user sets, rollback), `test_neo4j_cypher`
+(insert queries against a real graph).
+
+**Auth** — `test_oauth_service` (login/callback/CSRF state), `test_token_store`
+(namespacing, primary mirror), `test_refresh_token` (client auth, both-way
+mirror).
+
+**Resilience** — `test_engine_resilience` (429 cap / 401 refresh / 500
+give-up + dedup rollback, via mock failure injection),
+`test_engine_consumer_resilience` (queues survive reconnects),
+`test_engine_multiuser` (token envelopes per user).
+
+**End-to-end** — `test_e2e_crawl` (liked songs → graph), `test_discovery_e2e`
+(the depth-2 discography crawl), `test_multiplayer_e2e` (two users, overlap
+queries, migrations — the best narrative read in the suite),
+`test_mastering_e2e`.
+
+**Features** — `test_mastering_normalize` / `_clustering` / `_overrides` /
+`_backfill` / `_report`; `test_annotations_model` / `_annotate` / `_cypher` /
+`_tracker` / `_mock_player`; `test_playlist_generators` / `_sync` / `_mock`.
+
+**MCP server** — `test_mcp_server_readonly` (the write-blocking guard),
+`test_mcp_server_tools` (each tool against seeded data),
+`test_mcp_server_wiring` (registration completeness).
+
+**The mock itself** — `test_mock_service`, `test_mock_multiuser`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,19 +13,12 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def guard_real_secrets_untouched():
-    """Fail any test that writes token files under the REAL secrets/ dir.
+    """Fail any test that changes token files under the REAL secrets/ dir.
 
-    Regression guard for the secrets-clobber bug: token-store / OAuth / refresh
-    tests MUST monkeypatch the token paths (token_store.USERS_DIR,
-    PRIMARY_USER_FILE, LEGACY_*_TOKEN_FILE and refresh_token.SPOTIFY_*_FILE) to
-    tmp_path. A test that reaches the real SECRETS_DIR silently overwrites the
-    live app's Spotify tokens — the primary<->legacy two-way mirror in
-    refresh_token.py made an incompletely-isolated refresh test do exactly that,
-    turning secrets/spotify_api_token.secret (and the primary's namespaced copy)
-    into the literal "mock-access-token" on every `docker compose run tests`.
-
-    Snapshot the real token files before each test and assert they are
-    byte-for-byte unchanged after (covers writes, creations, and deletions).
+    Auth-adjacent tests MUST monkeypatch the token paths to tmp_path (see
+    tests/test_token_store.py::store); this snapshot-and-compare tripwire
+    turns a forgotten monkeypatch into a loud failure instead of silently
+    clobbered live tokens (the PR #27 bug — docs/testing.md has the story).
     """
     from application import config
 


### PR DESCRIPTION
A full documentation pass over the project, written for someone seeing it for the first time (portfolio/onboarding audience), plus the cleanup that fell out of the review.

## What's in here

**Topic docs (docs/), plain-English and top-down, with embedded Mermaid diagrams:**
- `architecture.md` — C4 levels 1–3: the system in its world, the Compose stack, inside the pipeline
- `data-model.md` — the graph model told through five data stories (a liked song's journey, mastering, multiplayer, annotations, playlists)
- `exploring-the-graph.md` — the "crawl is done, now what" tutorial: orientation, ten copy-paste questions, the two-user overlap tour
- `auth.md` — the OAuth flow end to end, token layout, refresh, scopes, and extraction-as-a-library notes
- `delivery.md` — the four run paths, one-image build, worktree isolation, explicit no-CI status, the AWS plan
- `observability.md` — the five windows into a running crawl, how to interpret them, honest gaps
- `testing.md` — the four test layers, safety rails, coverage gaps
- `docs/README.md` — reading order

**Diagrams, twice (for tool comparison):**
- A ten-page **Lucid** document with real product logos: [Spotify Power Browser — System Diagrams (C4)](https://lucid.app/lucidchart/092eb27a-7dda-48c1-9302-dcb6ab8ddde5/edit), regenerable from `docs/diagrams/gen_lucid.py`
- A structurally identical **Mermaid** twin of each page, embedded in the topic docs; `docs/diagrams/README.md` maps the pairs and frames the comparison

**Per-folder READMEs** for every component: all `application/` subsystems, `mcp_server/` (refreshed, incl. a ChatGPT Desktop gap section), `mock_spotify/`, `tests/`, `scripts/`.

**Agent skills** (`.claude/skills/`): run-tests, onboard-second-user, explore-graph, master-library, sync-playlists, connect-mcp, annotate-listening, mock-crawl — each a thin pointer to the docs with the key commands and cautions.

**Cleanup found during the review:**
- ROADMAP.md rewritten against reality (six plans shipped; the "four stub handlers" claim was half-stale)
- `docs/plans/README.md` gained a shipped-status column
- MCP server's stale "popularity not yet populated" claims updated (the plan 01 backfill shipped)
- One-off probe scripts moved from the repo root to `scripts/probes/` (paths fixed)
- Dead `check_url_match()` stubs removed from all handlers (never called; was on ROADMAP's cleanup list)
- The wordiest narrative comments (compose, conftest, engine, refresh, handlers, worktree hook) trimmed to constraint + doc pointer, now that the docs carry the story

## Verification
- Full suite in the isolated worktree stack: **425 passed, 80 skipped, 0 failed** (skips = no real secrets/Neo4j in the worktree, by design)
- All relative links across 46 markdown files verified to resolve
- Lucid pages 1/2/5 exported to PNG and visually checked (icons render; layout intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)